### PR TITLE
feat: 챗봇 RAG 적재 및 API 연동 추가

### DIFF
--- a/AI/ai_api.py
+++ b/AI/ai_api.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+<<<<<<< HEAD
 import sys
 import os
 import shutil
@@ -10,6 +11,17 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from ocr.pdf_extractor import extract_text_from_pdf
 from analysis.contract_analyzer import analyze_contract
 from analysis.chatbot_analyzer import answer_legal_question
+=======
+import os
+import shutil
+import sys
+
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+
+from ocr.pdf_extractor import extract_text_from_pdf
+from analysis.contract_analyzer import analyze_contract
+from analysis.chatbot_analyzer import answer_chat
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
 app = FastAPI()
 
@@ -22,6 +34,7 @@ class ChatRequest(BaseModel):
     question: str
 
 
+<<<<<<< HEAD
 @app.post("/api/ocr")
 async def ocr_pdf_file(file: UploadFile = File(...)):
     if not file.filename.lower().endswith(('.pdf', '.jpg', '.jpeg', '.png', 'txt')):
@@ -29,32 +42,65 @@ async def ocr_pdf_file(file: UploadFile = File(...)):
 
     file_location = f"temp_files/{file.filename}"
     os.makedirs(os.path.dirname(file_location), exist_ok=True)
+=======
+@app.get("/")
+async def root():
+    return {"message": "AI server is running"}
+
+
+@app.post("/api/ocr")
+async def ocr_pdf_file(file: UploadFile = File(...)):
+    if not file.filename.lower().endswith((".pdf", ".jpg", ".jpeg", ".png", ".txt")):
+        raise HTTPException(status_code=400, detail="지원하지 않는 파일 형식입니다.")
+
+    temp_dir = "temp_files"
+    os.makedirs(temp_dir, exist_ok=True)
+    file_location = os.path.join(temp_dir, file.filename)
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
     try:
         with open(file_location, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
 
         extracted_text = extract_text_from_pdf(file_location)
+<<<<<<< HEAD
 
         if os.path.exists(file_location):
             os.remove(file_location)
 
+=======
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
         return JSONResponse(content={"text": extracted_text})
 
     except Exception as e:
         print(f"❌ OCR 처리 중 에러 발생: {e}")
+<<<<<<< HEAD
 
         if os.path.exists(file_location):
             os.remove(file_location)
 
+=======
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
         raise HTTPException(status_code=500, detail=f"OCR 서버 오류: {str(e)}")
 
+    finally:
+        if os.path.exists(file_location):
+            os.remove(file_location)
 
+<<<<<<< HEAD
 @app.post("/api/ai-analyze")
 async def ai_analyze(request: AnalyzeRequest):
     try:
         result = analyze_contract(request.extracted_text)
         return JSONResponse(content=result)
+=======
+
+@app.post("/api/ai-analyze")
+async def analyze_text(request: AnalyzeRequest):
+    try:
+        ai_result = analyze_contract(request.extracted_text)
+        return JSONResponse(content=ai_result)
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
     except Exception as e:
         print(f"❌ AI 분석 중 에러 발생: {e}")
@@ -62,6 +108,7 @@ async def ai_analyze(request: AnalyzeRequest):
 
 
 @app.post("/api/chat")
+<<<<<<< HEAD
 async def chat_with_ai(request: ChatRequest):
     try:
         if not request.question or not request.question.strip():
@@ -72,6 +119,13 @@ async def chat_with_ai(request: ChatRequest):
 
     except HTTPException:
         raise
+=======
+async def chat_api(request: ChatRequest):
+    try:
+        answer = answer_chat(request.question)
+        return JSONResponse(content={"answer": answer})
+
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
     except Exception as e:
         print(f"❌ 챗봇 응답 중 에러 발생: {e}")
         raise HTTPException(status_code=500, detail=f"챗봇 서버 오류: {str(e)}")

--- a/AI/ai_api.py
+++ b/AI/ai_api.py
@@ -1,89 +1,77 @@
-# ai_api.py
-
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel  # 요청 및 응답 데이터 구조 정의를 위한 라이브러리
+from pydantic import BaseModel
 import sys
 import os
-import shutil  # 파일 복사 및 이동을 위한 유틸리티
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import shutil
 
-# 2. 기존 분석 함수 임포트
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from ocr.pdf_extractor import extract_text_from_pdf
 from analysis.contract_analyzer import analyze_contract
+from analysis.chatbot_analyzer import answer_legal_question
 
-
-# 3. FastAPI 애플리케이션 초기화
 app = FastAPI()
 
-# ----------------------------------------------------
-# 4. Pydantic 모델 정의: AI 분석 요청 시 데이터 구조
-# ----------------------------------------------------
-# Node.js에서 추출된 텍스트를 JSON 형태로 보낼 때, 
-# 이 구조(스키마)에 맞춰야 FastAPI가 데이터를 정상적으로 인식합니다.
-class AnalyzeRequest(BaseModel):
-    extracted_text: str # 필수 필드는 'extracted_text'이며 타입은 문자열(str)
 
-# 5. OCR 엔드포인트: PDF 파일을 받아 텍스트를 반환
-# POST /api/ocr
-@app.post("/api/ocr") # <--- Node.js가 파일 보내는 경로
+class AnalyzeRequest(BaseModel):
+    extracted_text: str
+
+
+class ChatRequest(BaseModel):
+    question: str
+
+
+@app.post("/api/ocr")
 async def ocr_pdf_file(file: UploadFile = File(...)):
-    # 1. 파일 형식 유효성 검사 (보안 및 로직 안정성 확보)
     if not file.filename.lower().endswith(('.pdf', '.jpg', '.jpeg', '.png', 'txt')):
         raise HTTPException(status_code=400, detail="지원하지 않는 파일 형식입니다.")
 
-    # 2. 임시 파일로 저장 경로 설정
-    # OCR 라이브러리는 파일 경로를 요구하는 경우가 많아, 서버에 임시로 저장합니다.
     file_location = f"temp_files/{file.filename}"
-    os.makedirs(os.path.dirname(file_location), exist_ok=True) # 폴더 없으면 생성
-    
+    os.makedirs(os.path.dirname(file_location), exist_ok=True)
+
     try:
-        # 3. 업로드된 파일 데이터를 임시 경로에 복사하여 저장
         with open(file_location, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
-        
-        # 4. OCR 함수 호출 (기존 ocr_example.py의 핵심 로직 실행)
-        extracted_text = extract_text_from_pdf(file_location)
-        
-        # 5. 임시 파일 삭제 (리소스 관리)
-        os.remove(file_location)
 
-        # 6. 결과 반환
-        # Node.js의 ai_service.js가 예상하는 JSON 형식으로 반환합니다: { "text": "..." }
-        return JSONResponse(content={"text": extracted_text})
-        
-    except Exception as e:
-        # OCR 실패 시 임시 파일 정리 및 500 에러 반환
-        print(f"❌ OCR 처리 중 에러 발생: {e}")
+        extracted_text = extract_text_from_pdf(file_location)
+
         if os.path.exists(file_location):
-            os.remove(file_location) # 에러 발생 시 파일이 남아있지 않도록 정리
+            os.remove(file_location)
+
+        return JSONResponse(content={"text": extracted_text})
+
+    except Exception as e:
+        print(f"❌ OCR 처리 중 에러 발생: {e}")
+
+        if os.path.exists(file_location):
+            os.remove(file_location)
+
         raise HTTPException(status_code=500, detail=f"OCR 서버 오류: {str(e)}")
 
 
-# ----------------------------------------------------
-# 6. AI 분석 엔드포인트: 텍스트를 받아 JSON 분석 결과를 반환
-# POST /api/ai-analyze
-# ----------------------------------------------------
-@app.post("/api/ai-analyze") # <--- Node.js가 텍스트 보내는 경로
-async def analyze_text(request: AnalyzeRequest):
+@app.post("/api/ai-analyze")
+async def ai_analyze(request: AnalyzeRequest):
     try:
-        # 1. AI 분석 함수 호출 (기존 ai_example.py의 핵심 로직 실행)
-        # 요청에서 파싱된 텍스트(request.extracted_text)를 인수로 전달합니다.
-        ai_result = analyze_contract(request.extracted_text)
-        
-        # 2. 결과 반환
-        # Node.js가 예상하는 최종 JSON 분석 결과를 반환합니다.
-        return JSONResponse(content=ai_result)
+        result = analyze_contract(request.extracted_text)
+        return JSONResponse(content=result)
 
     except Exception as e:
-        # 분석 실패 시 500 에러 반환
         print(f"❌ AI 분석 중 에러 발생: {e}")
         raise HTTPException(status_code=500, detail=f"AI 분석 서버 오류: {str(e)}")
 
-# ----------------------------------------------------
-# 7. 서버 실행 방법 (터미널 명령어)
-# ----------------------------------------------------
-# Python 환경에서 이 파일을 실행하는 명령어입니다.
-# Node.js의 AI_SERVER_URL(기본: http://localhost:8000)과 포트 번호를 일치시켜야 합니다.
-# uvicorn ai_api:app --host 0.0.0.0 --port 8000
+
+@app.post("/api/chat")
+async def chat_with_ai(request: ChatRequest):
+    try:
+        if not request.question or not request.question.strip():
+            raise HTTPException(status_code=400, detail="question 값이 필요합니다.")
+
+        result = answer_legal_question(request.question.strip())
+        return JSONResponse(content=result)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"❌ 챗봇 응답 중 에러 발생: {e}")
+        raise HTTPException(status_code=500, detail=f"챗봇 서버 오류: {str(e)}")

--- a/AI/analysis/chatbot_analyzer.py
+++ b/AI/analysis/chatbot_analyzer.py
@@ -1,0 +1,63 @@
+import os
+from dotenv import load_dotenv
+from google import genai
+
+from analysis.law_search import search_legal_sources, build_context_text
+
+load_dotenv()
+
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+GEMINI_CHAT_MODEL = os.getenv("GEMINI_CHAT_MODEL", "gemini-2.5-flash")
+
+if not GEMINI_API_KEY:
+    raise RuntimeError("GEMINI_API_KEY가 설정되어 있지 않습니다.")
+
+client = genai.Client(api_key=GEMINI_API_KEY)
+
+
+def answer_legal_question(question: str) -> dict:
+    grouped = search_legal_sources(question, top_k=8)
+    context_text = build_context_text(grouped)
+
+    prompt = f"""
+너는 법률 비전문가를 위한 AI 법률 챗봇이다.
+
+규칙:
+1. 어려운 법률 용어는 쉬운 말로 설명한다.
+2. 제공된 검색 결과에 근거해서만 답변한다.
+3. 모르면 "관련 정보를 찾을 수 없습니다"라고 말한다.
+4. 처음 서류를 작성하는 사람의 관점에서 설명한다.
+5. 검색 결과에 없는 법조문 번호나 판례번호를 임의로 만들지 않는다.
+
+반드시 아래 형식으로 답변하라.
+
+[쉬운 설명]
+- 이해하기 쉬운 말로 설명
+
+[법적 근거]
+- 관련 법령 / 해석 / 판례를 간단히 정리
+
+[대응 방법]
+- 사용자가 지금 할 수 있는 행동을 2~4개 안내
+
+[주의]
+- 불확실한 점이나 추가 확인이 필요한 부분 안내
+
+사용자 질문:
+{question}
+
+검색 결과:
+{context_text}
+""".strip()
+
+    response = client.models.generate_content(
+        model=GEMINI_CHAT_MODEL,
+        contents=prompt,
+    )
+
+    answer_text = response.text if hasattr(response, "text") else str(response)
+
+    return {
+        "answer": answer_text,
+        "references": grouped,
+    }

--- a/AI/analysis/chatbot_analyzer.py
+++ b/AI/analysis/chatbot_analyzer.py
@@ -7,6 +7,7 @@ from analysis.law_search import search_legal_sources, build_context_text
 load_dotenv()
 
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+<<<<<<< HEAD
 GEMINI_CHAT_MODEL = os.getenv("GEMINI_CHAT_MODEL", "gemini-2.5-flash")
 
 if not GEMINI_API_KEY:
@@ -61,3 +62,54 @@ def answer_legal_question(question: str) -> dict:
         "answer": answer_text,
         "references": grouped,
     }
+=======
+if not GEMINI_API_KEY:
+    raise RuntimeError("GEMINI_API_KEY가 설정되어 있지 않습니다.")
+
+gemini_client = genai.Client(api_key=GEMINI_API_KEY)
+
+
+def answer_chat(question: str) -> str:
+    question = (question or "").strip()
+    if not question:
+        return "질문이 비어 있습니다."
+
+    grouped = search_legal_sources(question, top_k=8)
+    context_text = build_context_text(grouped)
+
+    has_any_result = any(len(grouped[key]) > 0 for key in grouped)
+    if not has_any_result:
+        return "관련 정보를 찾을 수 없습니다. 다른 표현으로 다시 질문해 주세요."
+
+    prompt = f"""
+너는 부동산/임대차 계약 관련 법률 도우미다.
+
+아래 [검색 결과]만 근거로 사용해서 질문에 답변해라.
+
+규칙:
+1. 검색 결과에 없는 내용은 단정하지 말 것
+2. 법률 비전문가도 이해하기 쉬운 말로 설명할 것
+3. 가능하면 관련 법령명, 조문명, 용어명을 함께 언급할 것
+4. 질문이 "뜻", "의미", "뭐야", "정의" 같은 정의형 질문이면
+   가장 먼저 쉬운 한 줄 정의를 주고, 그다음 짧게 보충 설명할 것
+5. 답변은 너무 길지 않게 3~6문장 정도로 작성할 것
+6. 불확실하면 "검색 결과 기준으로는" 같은 표현을 사용할 것
+
+[사용자 질문]
+{question}
+
+[검색 결과]
+{context_text}
+""".strip()
+
+    response = gemini_client.models.generate_content(
+        model="gemini-2.5-flash",
+        contents=prompt,
+    )
+
+    answer = (response.text or "").strip()
+    if not answer:
+        return "답변을 생성하지 못했습니다."
+
+    return answer
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)

--- a/AI/analysis/law_search.py
+++ b/AI/analysis/law_search.py
@@ -1,5 +1,6 @@
 import os
 import sys
+<<<<<<< HEAD
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -7,26 +8,51 @@ from dotenv import load_dotenv
 from google import genai
 from google.genai import types
 from rag.db_utils import get_qdrant, LAW_COLLECTION
+=======
+from typing import Dict, List
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dotenv import load_dotenv
+from google import genai
+from google.genai import types
+from bson import ObjectId
+from fastembed import SparseTextEmbedding
+from qdrant_client import models
+
+from rag.db_utils import get_mongo_db, get_qdrant, LAW_COLLECTION
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
 load_dotenv()
 
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+<<<<<<< HEAD
 
+=======
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 if not GEMINI_API_KEY:
     raise RuntimeError("GEMINI_API_KEY가 설정되어 있지 않습니다.")
 
 gemini_client = genai.Client(api_key=GEMINI_API_KEY)
+<<<<<<< HEAD
+=======
+bm25_model = SparseTextEmbedding(model_name="Qdrant/bm25")
+
+DENSE_VECTOR_NAME = "dense"
+SPARSE_VECTOR_NAME = "sparse"
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
 
-def _embed(text: str) -> list[float]:
+def _embed_dense(text: str) -> list[float]:
     result = gemini_client.models.embed_content(
         model="gemini-embedding-2-preview",
         contents=text,
-        config=types.EmbedContentConfig(task_type="RETRIEVAL_QUERY")
+        config=types.EmbedContentConfig(task_type="RETRIEVAL_QUERY"),
     )
     return result.embeddings[0].values
 
 
+<<<<<<< HEAD
 def _normalize_hit(hit) -> dict:
     payload = hit.payload or {}
     return {
@@ -43,12 +69,49 @@ def _normalize_hit(hit) -> dict:
 
 def search_legal_sources(query: str, top_k: int = 8) -> dict:
     vector = _embed(query)
+=======
+def _embed_sparse(text: str) -> models.SparseVector:
+    emb = next(iter(bm25_model.embed([text])))
+    return models.SparseVector(indices=list(emb.indices), values=list(emb.values))
 
-    hits = get_qdrant().query_points(
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
+
+def _normalize_payload(hit_payload: dict, mongo_doc: dict | None, score: float) -> dict:
+    payload = hit_payload or {}
+    doc = mongo_doc or {}
+
+    return {
+        "score": score,
+        "type": payload.get("type") or doc.get("type") or ("law" if payload.get("law_name") or doc.get("law_name") else "unknown"),
+        "title": payload.get("title") or doc.get("title") or payload.get("article_title") or doc.get("article_title", ""),
+        "law_name": payload.get("law_name") or doc.get("law_name", ""),
+        "article": payload.get("article") or doc.get("article") or payload.get("article_num") or doc.get("article_num", ""),
+        "summary": payload.get("summary") or doc.get("summary", ""),
+        "content": payload.get("content") or doc.get("content", ""),
+        "source": payload.get("source") or doc.get("source", ""),
+        "effective_date": payload.get("effective_date") or doc.get("effective_date", ""),
+        "mongo_id": payload.get("mongo_id") or (str(doc.get("_id")) if doc.get("_id") else ""),
+    }
+
+
+def search_legal_sources(query: str, top_k: int = 8) -> Dict[str, List[Dict]]:
+    dense_vector = _embed_dense(query)
+    sparse_vector = _embed_sparse(query)
+
+    qdrant = get_qdrant()
+    db = get_mongo_db()
+    col = db["law_chunks"]
+
+    results = qdrant.query_points(
         collection_name=LAW_COLLECTION,
-        query=vector,
-        limit=top_k
-    ).points
+        prefetch=[
+            models.Prefetch(query=dense_vector, using=DENSE_VECTOR_NAME, limit=max(top_k * 3, 20)),
+            models.Prefetch(query=sparse_vector, using=SPARSE_VECTOR_NAME, limit=max(top_k * 3, 20)),
+        ],
+        query=models.FusionQuery(fusion=models.Fusion.RRF),
+        with_payload=True,
+        limit=top_k,
+    )
 
     grouped = {
         "terms": [],
@@ -58,11 +121,29 @@ def search_legal_sources(query: str, top_k: int = 8) -> dict:
         "cases": [],
         "others": [],
     }
+<<<<<<< HEAD
 
     for hit in hits:
         doc = _normalize_hit(hit)
         doc_type = doc["type"]
 
+=======
+
+    for hit in results.points:
+        payload = hit.payload or {}
+        mongo_doc = None
+
+        mongo_id = payload.get("mongo_id")
+        if mongo_id:
+            try:
+                mongo_doc = col.find_one({"_id": ObjectId(mongo_id)})
+            except Exception:
+                mongo_doc = None
+
+        doc = _normalize_payload(payload, mongo_doc, getattr(hit, "score", 0))
+        doc_type = doc["type"]
+
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
         if doc_type == "term":
             grouped["terms"].append(doc)
         elif doc_type == "knowledge":
@@ -79,8 +160,13 @@ def search_legal_sources(query: str, top_k: int = 8) -> dict:
     return grouped
 
 
+<<<<<<< HEAD
 def build_context_text(grouped: dict) -> str:
     def format_docs(title: str, docs: list[dict]) -> str:
+=======
+def build_context_text(grouped: Dict[str, List[Dict]]) -> str:
+    def format_docs(title: str, docs: List[Dict]) -> str:
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
         if not docs:
             return f"[{title}]\n없음\n"
 
@@ -88,6 +174,7 @@ def build_context_text(grouped: dict) -> str:
         for i, doc in enumerate(docs, start=1):
             lines.append(
                 f"""({i})
+<<<<<<< HEAD
 제목: {doc.get("title", "")}
 법령명: {doc.get("law_name", "")}
 조문: {doc.get("article", "")}
@@ -95,6 +182,15 @@ def build_context_text(grouped: dict) -> str:
 내용: {doc.get("content", "")}
 출처: {doc.get("source", "")}
 유사도점수: {doc.get("score", 0)}"""
+=======
+제목: {doc.get('title', '')}
+법령명: {doc.get('law_name', '')}
+조문: {doc.get('article', '')}
+요약: {doc.get('summary', '')}
+내용: {doc.get('content', '')}
+출처: {doc.get('source', '')}
+유사도점수: {doc.get('score', 0)}"""
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
             )
         lines.append("")
         return "\n".join(lines)
@@ -109,19 +205,30 @@ def build_context_text(grouped: dict) -> str:
     ])
 
 
+<<<<<<< HEAD
 # 기존 contract_analyzer.py와 호환용 함수
+=======
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 def search_laws(query: str, top_k: int = 5) -> list[dict]:
     grouped = search_legal_sources(query, top_k=top_k)
 
     merged = []
+<<<<<<< HEAD
 
     for doc in grouped["laws"]:
+=======
+    for doc in grouped["laws"] + grouped["others"]:
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
         merged.append({
             "lawName": doc.get("law_name", ""),
             "articleNum": doc.get("article", ""),
             "articleTitle": doc.get("title", ""),
             "content": doc.get("content", ""),
+<<<<<<< HEAD
             "score": doc.get("score", 0),
+=======
+            "score": round(doc.get("score", 0), 4),
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
         })
 
     return merged

--- a/AI/analysis/law_search.py
+++ b/AI/analysis/law_search.py
@@ -1,16 +1,21 @@
 import os
 import sys
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+from dotenv import load_dotenv
 from google import genai
 from google.genai import types
-from dotenv import load_dotenv
-from bson import ObjectId
-from rag.db_utils import get_mongo_db, get_qdrant, LAW_COLLECTION
+from rag.db_utils import get_qdrant, LAW_COLLECTION
 
 load_dotenv()
 
-gemini_client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+
+if not GEMINI_API_KEY:
+    raise RuntimeError("GEMINI_API_KEY가 설정되어 있지 않습니다.")
+
+gemini_client = genai.Client(api_key=GEMINI_API_KEY)
 
 
 def _embed(text: str) -> list[float]:
@@ -22,22 +27,21 @@ def _embed(text: str) -> list[float]:
     return result.embeddings[0].values
 
 
-def search_laws(query: str, top_k: int = 5) -> list[dict]:
-    """
-    계약서 텍스트(또는 위험 조항)를 받아 관련 법령 조문을 검색.
+def _normalize_hit(hit) -> dict:
+    payload = hit.payload or {}
+    return {
+        "title": payload.get("title", ""),
+        "law_name": payload.get("law_name", ""),
+        "article": payload.get("article", ""),
+        "summary": payload.get("summary", ""),
+        "content": payload.get("content", ""),
+        "source": payload.get("source", ""),
+        "type": payload.get("type", "unknown"),
+        "score": round(hit.score, 4),
+    }
 
-    반환 예시:
-    [
-      {
-        "lawName": "주택임대차보호법",
-        "articleNum": "3",
-        "articleTitle": "대항력 등",
-        "content": "제3조(대항력 등) ...",
-        "score": 0.91
-      },
-      ...
-    ]
-    """
+
+def search_legal_sources(query: str, top_k: int = 8) -> dict:
     vector = _embed(query)
 
     hits = get_qdrant().query_points(
@@ -46,22 +50,78 @@ def search_laws(query: str, top_k: int = 5) -> list[dict]:
         limit=top_k
     ).points
 
-    if not hits:
-        return []
-
-    col = get_mongo_db()["law_chunks"]
-    results = []
+    grouped = {
+        "terms": [],
+        "knowledge": [],
+        "laws": [],
+        "interpretations": [],
+        "cases": [],
+        "others": [],
+    }
 
     for hit in hits:
-        mongo_id = hit.payload.get("mongo_id")
-        doc = col.find_one({"_id": ObjectId(mongo_id)})
-        if doc:
-            results.append({
-                "lawName": doc["law_name"],
-                "articleNum": doc["article_num"],
-                "articleTitle": doc.get("article_title", ""),
-                "content": doc["content"],
-                "score": round(hit.score, 4),
-            })
+        doc = _normalize_hit(hit)
+        doc_type = doc["type"]
 
-    return results
+        if doc_type == "term":
+            grouped["terms"].append(doc)
+        elif doc_type == "knowledge":
+            grouped["knowledge"].append(doc)
+        elif doc_type == "law":
+            grouped["laws"].append(doc)
+        elif doc_type == "interpret":
+            grouped["interpretations"].append(doc)
+        elif doc_type == "case":
+            grouped["cases"].append(doc)
+        else:
+            grouped["others"].append(doc)
+
+    return grouped
+
+
+def build_context_text(grouped: dict) -> str:
+    def format_docs(title: str, docs: list[dict]) -> str:
+        if not docs:
+            return f"[{title}]\n없음\n"
+
+        lines = [f"[{title}]"]
+        for i, doc in enumerate(docs, start=1):
+            lines.append(
+                f"""({i})
+제목: {doc.get("title", "")}
+법령명: {doc.get("law_name", "")}
+조문: {doc.get("article", "")}
+요약: {doc.get("summary", "")}
+내용: {doc.get("content", "")}
+출처: {doc.get("source", "")}
+유사도점수: {doc.get("score", 0)}"""
+            )
+        lines.append("")
+        return "\n".join(lines)
+
+    return "\n".join([
+        format_docs("법령용어", grouped["terms"]),
+        format_docs("지식베이스", grouped["knowledge"]),
+        format_docs("현행법령", grouped["laws"]),
+        format_docs("법령해석", grouped["interpretations"]),
+        format_docs("판례", grouped["cases"]),
+        format_docs("기타", grouped["others"]),
+    ])
+
+
+# 기존 contract_analyzer.py와 호환용 함수
+def search_laws(query: str, top_k: int = 5) -> list[dict]:
+    grouped = search_legal_sources(query, top_k=top_k)
+
+    merged = []
+
+    for doc in grouped["laws"]:
+        merged.append({
+            "lawName": doc.get("law_name", ""),
+            "articleNum": doc.get("article", ""),
+            "articleTitle": doc.get("title", ""),
+            "content": doc.get("content", ""),
+            "score": doc.get("score", 0),
+        })
+
+    return merged

--- a/AI/check_qdrant.py
+++ b/AI/check_qdrant.py
@@ -1,0 +1,79 @@
+import os
+from collections import Counter
+from dotenv import load_dotenv
+from qdrant_client import QdrantClient
+
+load_dotenv()
+
+QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
+QDRANT_API_KEY = os.getenv("QDRANT_API_KEY", "")
+COLLECTION_NAME = "law_chunks"
+
+if QDRANT_API_KEY:
+    client = QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY)
+else:
+    client = QdrantClient(url=QDRANT_URL)
+
+def main():
+    try:
+        info = client.get_collection(COLLECTION_NAME)
+        print("=== 컬렉션 정보 ===")
+        print(info)
+
+        count_result = client.count(collection_name=COLLECTION_NAME, exact=True)
+        print(f"\n=== 총 저장된 데이터 개수 ===\n{count_result.count}")
+
+        all_points = []
+        next_page_offset = None
+
+        while True:
+            points, next_page_offset = client.scroll(
+                collection_name=COLLECTION_NAME,
+                limit=100,
+                offset=next_page_offset,
+                with_payload=True,
+                with_vectors=False,
+            )
+            all_points.extend(points)
+
+            if next_page_offset is None:
+                break
+
+        print(f"\n=== 실제 읽어온 데이터 개수 ===\n{len(all_points)}")
+
+        type_counter = Counter()
+        for point in all_points:
+            payload = point.payload or {}
+            doc_type = payload.get("type", "unknown")
+            type_counter[doc_type] += 1
+
+        print("\n=== type별 개수 ===")
+        for doc_type, count in type_counter.items():
+            print(f"{doc_type}: {count}개")
+
+        print("\n=== law 샘플 ===")
+        law_sample = next((p for p in all_points if (p.payload or {}).get("type") == "law"), None)
+        if law_sample:
+            print(law_sample.payload)
+        else:
+            print("law 데이터 없음")
+
+        print("\n=== term 샘플 ===")
+        term_sample = next((p for p in all_points if (p.payload or {}).get("type") == "term"), None)
+        if term_sample:
+            print(term_sample.payload)
+        else:
+            print("term 데이터 없음")
+
+        print("\n=== knowledge 샘플 ===")
+        knowledge_sample = next((p for p in all_points if (p.payload or {}).get("type") == "knowledge"), None)
+        if knowledge_sample:
+            print(knowledge_sample.payload)
+        else:
+            print("knowledge 데이터 없음")
+
+    except Exception as e:
+        print("Qdrant 확인 중 오류 발생:", e)
+
+if __name__ == "__main__":
+    main()

--- a/AI/rag/db_utils.py
+++ b/AI/rag/db_utils.py
@@ -1,26 +1,48 @@
 import os
+<<<<<<< HEAD
 import uuid
 from pymongo import MongoClient
 from qdrant_client import QdrantClient
 from qdrant_client.models import Distance, VectorParams
+=======
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 from dotenv import load_dotenv
+from pymongo import MongoClient
+from qdrant_client import QdrantClient, models
+from bson import ObjectId
+import uuid
 
 load_dotenv()
 
-MONGO_URL = os.getenv("MONGO_URL")
-QDRANT_URL = os.getenv("QDRANT_URL")
-QDRANT_API_KEY = os.getenv("QDRANT_API_KEY")
+MONGODB_URI = (
+    os.getenv("MONGODB_URI")
+    or os.getenv("MONGO_URI")
+    or os.getenv("MONGO_URL")
+)
 
-LAW_COLLECTION = "law_chunks"
-VECTOR_SIZE = 3072  # Gemini gemini-embedding-2-preview 차원 수
+QDRANT_URL = os.getenv("QDRANT_URL", "http://qdrant:6333")
+QDRANT_API_KEY = os.getenv("QDRANT_API_KEY", "")
+LAW_COLLECTION = os.getenv("LAW_COLLECTION", "law_chunks")
+
+DENSE_VECTOR_NAME = "dense"
+SPARSE_VECTOR_NAME = "sparse"
+DENSE_VECTOR_SIZE = 3072
 
 
 def get_mongo_db():
-    client = MongoClient(MONGO_URL)
-    return client["AI_LawDoctor"]
+    if not MONGODB_URI:
+        raise RuntimeError(
+            "MongoDB 연결 문자열이 없습니다. "
+            "MONGODB_URI / MONGO_URI / MONGO_URL 중 하나를 설정하세요."
+        )
+
+    client = MongoClient(MONGODB_URI)
+    db_name = MONGODB_URI.rsplit("/", 1)[-1].split("?")[0]
+    return client[db_name]
 
 
 def get_qdrant():
+<<<<<<< HEAD
     return QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY)
 
 
@@ -39,3 +61,33 @@ def ensure_qdrant_collection(qdrant: QdrantClient):
 def objectid_to_uuid(object_id) -> str:
     """MongoDB ObjectId → 결정론적 UUID 변환 (uuid5 방식)"""
     return str(uuid.uuid5(uuid.NAMESPACE_DNS, str(object_id)))
+=======
+    if QDRANT_API_KEY:
+        return QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY)
+    return QdrantClient(url=QDRANT_URL)
+
+
+def objectid_to_uuid(obj_id: ObjectId) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, str(obj_id)))
+
+
+def ensure_qdrant_collection(qdrant: QdrantClient):
+    collections = [c.name for c in qdrant.get_collections().collections]
+    if LAW_COLLECTION in collections:
+        return
+
+    qdrant.create_collection(
+        collection_name=LAW_COLLECTION,
+        vectors_config={
+            DENSE_VECTOR_NAME: models.VectorParams(
+                size=DENSE_VECTOR_SIZE,
+                distance=models.Distance.COSINE,
+            )
+        },
+        sparse_vectors_config={
+            SPARSE_VECTOR_NAME: models.SparseVectorParams(
+                modifier=models.Modifier.IDF
+            )
+        },
+    )
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)

--- a/AI/rag/init_rag.py
+++ b/AI/rag/init_rag.py
@@ -9,54 +9,71 @@
 import os
 import sys
 import time
-import uuid
 import requests
 import xml.etree.ElementTree as ET
 from datetime import date
 from dotenv import load_dotenv
 from google import genai
 from google.genai import types
+<<<<<<< HEAD
 from qdrant_client.models import PointStruct
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+=======
+from fastembed import SparseTextEmbedding
+from qdrant_client.models import PointStruct, SparseVector
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 load_dotenv()
 
-from rag.db_utils import get_mongo_db, get_qdrant, ensure_qdrant_collection, objectid_to_uuid, LAW_COLLECTION
+from rag.db_utils import (
+    get_mongo_db,
+    get_qdrant,
+    ensure_qdrant_collection,
+    objectid_to_uuid,
+    LAW_COLLECTION,
+)
 
 LAW_OC = os.getenv("LAW_OC")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 
 if not LAW_OC or not GEMINI_API_KEY:
-    print("LAW_OC 또는 GEMINI_API_KEY가 설정되지 않았습니다.")
+    print("LAW_OC 또는 GEMINI_API_KEY가 설정되어 있지 않습니다.")
     sys.exit(1)
 
 gemini_client = genai.Client(api_key=GEMINI_API_KEY)
+bm25_model = SparseTextEmbedding(model_name="Qdrant/bm25")
+
 BASE_URL = "https://www.law.go.kr/DRF"
+DENSE_VECTOR_NAME = "dense"
+SPARSE_VECTOR_NAME = "sparse"
 
 # 부동산 계약 관련 법령 (민법은 618~654조만)
 TARGET_LAWS = [
-    {"name": "주택임대차보호법",    "mst": "276291",    "filter_articles": None},
-    {"name": "주택임대차보호법 시행령",    "mst": "280995",     "filter_articles": None},
+    {"name": "주택임대차보호법", "mst": "276291", "filter_articles": None},
+    {"name": "주택임대차보호법 시행령", "mst": "280995", "filter_articles": None},
 
-    {"name": "상가건물 임대차보호법",   "mst": "276285",    "filter_articles": None},
-    {"name": "상가건물 임대차보호법 시행령",    "mst": "280987",    "filter_articles": None},
+    {"name": "상가건물 임대차보호법", "mst": "276285", "filter_articles": None},
+    {"name": "상가건물 임대차보호법 시행령", "mst": "280987", "filter_articles": None},
 
-    {"name": "부동산 거래신고 등에 관한 법률",      "mst": "259641" ,    "filter_articles": None},
-    {"name": "부동산 거래신고 등에 관한 법률 시행령",   "mst": "283653",    "filter_articles": None},
-    {"name": "부동산 거래신고 등에 관한 법률 시행규칙",     "mst": "283339",  "filter_articles": None},
+    {"name": "부동산 거래신고 등에 관한 법률", "mst": "259641", "filter_articles": None},
+    {"name": "부동산 거래신고 등에 관한 법률 시행령", "mst": "283653", "filter_articles": None},
+    {"name": "부동산 거래신고 등에 관한 법률 시행규칙", "mst": "283339", "filter_articles": None},
 
-    {"name": "공인중개사법",    "mst": "273341" ,   "filter_articles": None},
-    {"name": "공인중개사법 시행령",      "mst": "279243" ,    "filter_articles": None},
-    {"name": "공인중개사법 시행규칙",      "mst": "263573" ,    "filter_articles": None},
-    {"name": "공인중개사의 매수신청대리인 등록 등에 관한 규칙",      "mst": "244751" ,    "filter_articles": None},
+    {"name": "공인중개사법", "mst": "273341", "filter_articles": None},
+    {"name": "공인중개사법 시행령", "mst": "279243", "filter_articles": None},
+    {"name": "공인중개사법 시행규칙", "mst": "263573", "filter_articles": None},
+    {"name": "공인중개사의 매수신청대리인 등록 등에 관한 규칙", "mst": "244751", "filter_articles": None},
 
-    {"name": "집합건물의 소유 및 관리에 관한 법률",    "mst": "249285" ,   "filter_articles": None},
-    {"name": "집합건물의 소유 및 관리에 관한 법률 시행령",    "mst": "254889" ,   "filter_articles": None},
+    {"name": "집합건물의 소유 및 관리에 관한 법률", "mst": "249285", "filter_articles": None},
+    {"name": "집합건물의 소유 및 관리에 관한 법률 시행령", "mst": "254889", "filter_articles": None},
 
-    {"name": "전세사기피해자 지원 및 주거안정에 관한 특별법",    "mst": "277021" ,   "filter_articles": None},
-    {"name": "전세사기피해자 지원 및 주거안정에 관한 특별법 시행령",    "mst": "266295" ,   "filter_articles": None},
-    {"name": "전세사기피해자 지원 및 주거안정에 관한 특별법 시행규칙",    "mst": "273851" ,   "filter_articles": None},
+    {"name": "전세사기피해자 지원 및 주거안정에 관한 특별법", "mst": "277021", "filter_articles": None},
+    {"name": "전세사기피해자 지원 및 주거안정에 관한 특별법 시행령", "mst": "266295", "filter_articles": None},
+    {"name": "전세사기피해자 지원 및 주거안정에 관한 특별법 시행규칙", "mst": "273851", "filter_articles": None},
 
+<<<<<<< HEAD
     {"name": "부동산등기규칙",    "mst": "266847" ,   "filter_articles": None},
     {"name": "부동산등기법",    "mst": "265377" ,   "filter_articles": None},
     {"name": "축사의 부동산등기에 관한 특례법",    "mst": "210145" ,   "filter_articles": None},
@@ -74,10 +91,26 @@ TARGET_LAWS = [
     {"name": "주택법 시행규칙",    "mst": "284551" ,   "filter_articles": None},
 
     {"name": "민법",    "mst": "284415" ,   "filter_articles": set(range(618, 655))},
+=======
+    {"name": "부동산등기규칙", "mst": "266847", "filter_articles": None},
+    {"name": "부동산등기법", "mst": "265377", "filter_articles": None},
+    {"name": "축사의 부동산등기에 관한 특례법", "mst": "210145", "filter_articles": None},
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
+    {"name": "민간임대주택에 관한 특별법", "mst": "276995", "filter_articles": None},
+    {"name": "민간임대주택에 관한 특별법 시행령", "mst": "269343", "filter_articles": None},
+    {"name": "민간임대주택에 관한 특별법 시행규칙", "mst": "280639", "filter_articles": None},
+    {"name": "부도공공건설임대주택 임차인 보호를 위한 특별법", "mst": "174491", "filter_articles": None},
+    {"name": "부도공공건설임대주택 임차인 보호를 위한 특별법 시행령", "mst": "185425", "filter_articles": None},
+    {"name": "장기공공임대주택 입주자 삶의 질 향상 지원법", "mst": "273421", "filter_articles": None},
+    {"name": "장기공공임대주택 입주자 삶의 질 향상 지원법 시행령", "mst": "283499", "filter_articles": None},
+    {"name": "장기공공임대주택 입주자 삶의 질 향상 지원법 시행규칙", "mst": "185553", "filter_articles": None},
+    {"name": "주택법", "mst": "283191", "filter_articles": None},
+    {"name": "주택법 시행령", "mst": "281851", "filter_articles": None},
+    {"name": "주택법 시행규칙", "mst": "284551", "filter_articles": None},
 
+    {"name": "민법", "mst": "284415", "filter_articles": set(range(618, 655))},
 ]
-
 
 
 def parse_article_text(article) -> str:
@@ -113,12 +146,12 @@ def parse_article_text(article) -> str:
 
 
 def fetch_law_articles(mst: str, law_name: str, filter_articles=None) -> list[dict]:
-    """법제처 API: MST -> 조문 목록 파싱 (항/호/목 계층 보존)"""
+    """법제처 API: MST -> 조문 목록 파싱"""
     try:
         resp = requests.get(
             f"{BASE_URL}/lawService.do",
             params={"OC": LAW_OC, "target": "law", "MST": mst, "type": "XML"},
-            timeout=30
+            timeout=30,
         )
         root = ET.fromstring(resp.content)
     except Exception as e:
@@ -144,6 +177,7 @@ def fetch_law_articles(mst: str, law_name: str, filter_articles=None) -> list[di
             continue
 
         articles.append({
+            "type": "law",
             "law_name": law_name,
             "article_num": num_str,
             "article_title": (article.findtext("조문제목") or "").strip(),
@@ -156,14 +190,21 @@ def fetch_law_articles(mst: str, law_name: str, filter_articles=None) -> list[di
     return articles
 
 
-def embed_text(text: str) -> list[float]:
-    """Gemini gemini-embedding-2-preview로 임베딩 (저장용)"""
+def embed_dense(text: str) -> list[float]:
     result = gemini_client.models.embed_content(
         model="gemini-embedding-2-preview",
         contents=text,
-        config=types.EmbedContentConfig(task_type="RETRIEVAL_DOCUMENT")
+        config=types.EmbedContentConfig(task_type="RETRIEVAL_DOCUMENT"),
     )
     return result.embeddings[0].values
+
+
+def embed_sparse(text: str) -> SparseVector:
+    emb = next(iter(bm25_model.embed([text])))
+    return SparseVector(
+        indices=list(emb.indices),
+        values=list(emb.values),
+    )
 
 
 def step1_collect_laws(db):
@@ -175,7 +216,7 @@ def step1_collect_laws(db):
         law_name = law_info["name"]
         filter_articles = law_info["filter_articles"]
 
-        existing = col.count_documents({"law_name": law_name})
+        existing = col.count_documents({"law_name": law_name, "type": "law"})
         if existing > 0:
             print(f"  {law_name}: 이미 {existing}개 저장됨, 스킵")
             continue
@@ -194,13 +235,17 @@ def step1_collect_laws(db):
 
 
 def step2_embed_and_store(db, qdrant):
+<<<<<<< HEAD
     """Step 2: PENDING 항목만 임베딩 -> Qdrant 저장 (이어쓰기 지원)"""
+=======
+    """Step 2: PENDING law 항목만 임베딩 -> Qdrant 저장"""
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
     col = db["law_chunks"]
-    pending = list(col.find({"process_status": "PENDING"}))
+    pending = list(col.find({"process_status": "PENDING", "type": "law"}))
     total = len(pending)
 
     if total == 0:
-        print("\n[Step 2] 모든 항목이 이미 임베딩 완료되었습니다.")
+        print("\n[Step 2] 모든 law 항목이 이미 임베딩 완료되었습니다.")
         return
 
     print(f"\n[Step 2] 임베딩 시작: {total}개 항목")
@@ -211,10 +256,13 @@ def step2_embed_and_store(db, qdrant):
         text = f"{doc['law_name']} {doc['content']}"
 
         retries = 0
-        vector = None
+        dense_vector = None
+        sparse_vector = None
+
         while retries < 3:
             try:
-                vector = embed_text(text)
+                dense_vector = embed_dense(text)
+                sparse_vector = embed_sparse(text)
                 break
             except Exception as e:
                 retries += 1
@@ -222,7 +270,7 @@ def step2_embed_and_store(db, qdrant):
                 print(f"  임베딩 실패 ({retries}/3), {wait}초 대기: {e}")
                 time.sleep(wait)
 
-        if vector is None:
+        if dense_vector is None or sparse_vector is None:
             print(f"  최대 재시도 초과, 스킵: {doc['_id']}")
             continue
 
@@ -233,27 +281,47 @@ def step2_embed_and_store(db, qdrant):
             points=[
                 PointStruct(
                     id=qdrant_id,
+<<<<<<< HEAD
                     vector=vector,
                     payload={
                         "mongo_id": str(doc["_id"]),
+=======
+                    vector={
+                        DENSE_VECTOR_NAME: dense_vector,
+                        SPARSE_VECTOR_NAME: sparse_vector,
+                    },
+                    payload={
+                        "mongo_id": str(doc["_id"]),
+                        "type": "law",
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
                         "law_name": doc["law_name"],
                         "article_num": doc["article_num"],
                         "article_title": doc["article_title"],
                         "effective_date": doc["effective_date"],
+<<<<<<< HEAD
                     }
                 )
             ]
+=======
+                    },
+                )
+            ],
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
         )
 
         col.update_one(
             {"_id": doc["_id"]},
+<<<<<<< HEAD
             {"$set": {"process_status": "DONE", "qdrant_id": qdrant_id}}
+=======
+            {"$set": {"process_status": "DONE", "qdrant_id": qdrant_id}},
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
         )
 
-        time.sleep(4)
+        time.sleep(1)
 
-    done = col.count_documents({"process_status": "DONE"})
-    total_all = col.count_documents({})
+    done = col.count_documents({"process_status": "DONE", "type": "law"})
+    total_all = col.count_documents({"type": "law"})
     print(f"\n임베딩 완료: {done}개 / {total_all}개")
 
 

--- a/AI/rag/upsert_term_knowledge_from_api.py
+++ b/AI/rag/upsert_term_knowledge_from_api.py
@@ -1,0 +1,353 @@
+import os
+import sys
+import json
+import hashlib
+import requests
+from dotenv import load_dotenv
+from google import genai
+from google.genai import types
+from qdrant_client.models import PointStruct
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from rag.db_utils import get_qdrant, LAW_COLLECTION
+
+load_dotenv()
+
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+LAW_OC = os.getenv("LAW_OC")
+
+if not GEMINI_API_KEY:
+    raise RuntimeError("GEMINI_API_KEY가 .env에 설정되어 있지 않습니다.")
+
+if not LAW_OC:
+    raise RuntimeError("LAW_OC가 .env에 설정되어 있지 않습니다.")
+
+gemini_client = genai.Client(api_key=GEMINI_API_KEY)
+qdrant = get_qdrant()
+
+TERM_API_URL = "https://www.law.go.kr/DRF/lawSearch.do"
+KNOWLEDGE_API_URL = "https://www.law.go.kr/DRF/lawSearch.do"
+
+PROGRESS_FILE = os.path.join(os.path.dirname(__file__), "..", "data", "upsert_progress.json")
+
+TERM_QUERIES = [
+    "임대인",
+    "임차인",
+    "묵시적 갱신",
+    "계약갱신요구권",
+    "보증금",
+    "전대차",
+    "위약금",
+]
+
+KNOWLEDGE_QUERIES = [
+    "임대차",
+    "보증금",
+    "계약갱신요구권",
+    "전대차",
+    "묵시적 갱신",
+    "위약금",
+]
+
+
+def load_progress():
+    if not os.path.exists(PROGRESS_FILE):
+        return {
+            "term": {"query_index": 0, "page": 1},
+            "knowledge": {"query_index": 0, "page": 1},
+        }
+
+    with open(PROGRESS_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_progress(progress):
+    os.makedirs(os.path.dirname(PROGRESS_FILE), exist_ok=True)
+    with open(PROGRESS_FILE, "w", encoding="utf-8") as f:
+        json.dump(progress, f, ensure_ascii=False, indent=2)
+
+
+def embed_text(text: str) -> list[float]:
+    result = gemini_client.models.embed_content(
+        model="gemini-embedding-2-preview",
+        contents=text,
+        config=types.EmbedContentConfig(task_type="RETRIEVAL_DOCUMENT"),
+    )
+    return result.embeddings[0].values
+
+
+def get_start_id() -> int:
+    count_result = qdrant.count(collection_name=LAW_COLLECTION, exact=True)
+    return count_result.count + 1
+
+
+def make_embedding_input(doc: dict, doc_type: str) -> str:
+    return f"""
+유형: {doc_type}
+제목: {doc.get("title", "")}
+법령명: {doc.get("law_name", "")}
+조문: {doc.get("article", "")}
+요약: {doc.get("summary", "")}
+내용: {doc.get("content", "")}
+출처: {doc.get("source", "")}
+""".strip()
+
+
+def extract_items_from_json(data):
+    if isinstance(data, list):
+        return data
+
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if isinstance(value, list):
+                print(f"응답에서 '{key}' 리스트를 찾았습니다. 개수: {len(value)}")
+                return value
+            elif isinstance(value, dict):
+                result = extract_items_from_json(value)
+                if result:
+                    return result
+
+    return []
+
+
+def make_unique_key(doc: dict) -> str:
+    raw = f"{doc.get('type', '')}|{doc.get('title', '')}|{doc.get('law_name', '')}|{doc.get('article', '')}"
+    return raw.strip()
+
+
+def make_unique_hash(doc: dict) -> str:
+    key = make_unique_key(doc)
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+
+def load_existing_hashes() -> set[str]:
+    existing_hashes = set()
+    next_page_offset = None
+
+    while True:
+        points, next_page_offset = qdrant.scroll(
+            collection_name=LAW_COLLECTION,
+            limit=200,
+            offset=next_page_offset,
+            with_payload=True,
+            with_vectors=False,
+        )
+
+        for point in points:
+            payload = point.payload or {}
+
+            unique_hash = payload.get("unique_hash")
+            if unique_hash:
+                existing_hashes.add(unique_hash)
+                continue
+
+            if any(k in payload for k in ["type", "title", "law_name", "article"]):
+                computed_hash = make_unique_hash(payload)
+                existing_hashes.add(computed_hash)
+
+        if next_page_offset is None:
+            break
+
+    return existing_hashes
+
+
+def upsert_docs(docs: list[dict], doc_type: str, start_id: int, existing_hashes: set[str]):
+    if not docs:
+        print(f"{doc_type} 데이터가 없습니다.")
+        return start_id, 0
+
+    current_id = start_id
+    inserted_count = 0
+    skipped_count = 0
+
+    for idx, doc in enumerate(docs, start=1):
+        try:
+            doc["type"] = doc_type
+            unique_hash = make_unique_hash(doc)
+
+            if unique_hash in existing_hashes:
+                skipped_count += 1
+                print(f"{doc_type} 중복 건너뜀: title={doc.get('title', '')}")
+                continue
+
+            doc["unique_hash"] = unique_hash
+
+            text = make_embedding_input(doc, doc_type)
+            vector = embed_text(text)
+
+            qdrant.upsert(
+                collection_name=LAW_COLLECTION,
+                points=[
+                    PointStruct(
+                        id=current_id,
+                        vector=vector,
+                        payload=doc,
+                    )
+                ],
+            )
+
+            existing_hashes.add(unique_hash)
+            inserted_count += 1
+
+            print(f"{doc_type} 저장 완료: id={current_id}, title={doc.get('title', '')}")
+            current_id += 1
+
+        except Exception as e:
+            print(f"{doc_type} 업로드 실패 ({idx}번째): {e}")
+
+    print(f"{doc_type} 업로드 완료: 신규 {inserted_count}개, 중복 스킵 {skipped_count}개")
+    return current_id, inserted_count
+
+
+def fetch_term_page(query: str, page: int) -> list[dict]:
+    params = {
+        "OC": LAW_OC,
+        "target": "lstrmAI",
+        "type": "JSON",
+        "query": query,
+        "display": 20,
+        "page": page,
+    }
+
+    response = requests.get(TERM_API_URL, params=params, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    items = extract_items_from_json(data)
+
+    docs = []
+    for item in items:
+        docs.append({
+            "type": "term",
+            "title": item.get("법령용어명", "") or item.get("용어명", "") or item.get("title", "") or item.get("wordName", ""),
+            "law_name": item.get("법령명", "") or item.get("law_name", "") or item.get("lawTitle", ""),
+            "article": item.get("조문번호", "") or item.get("article", "") or item.get("articleNum", ""),
+            "summary": item.get("설명", "") or item.get("정의", "") or item.get("wordMeaning", "") or item.get("summary", ""),
+            "content": item.get("설명", "") or item.get("정의", "") or item.get("wordMeaning", "") or item.get("content", ""),
+            "source": "법령용어",
+        })
+
+    print(f"[term] query='{query}' page={page} -> {len(docs)}개")
+    return docs
+
+
+def fetch_knowledge_page(query: str, page: int) -> list[dict]:
+    params = {
+        "OC": LAW_OC,
+        "target": "aiSearch",
+        "type": "JSON",
+        "search": 0,
+        "query": query,
+        "display": 20,
+        "page": page,
+    }
+
+    response = requests.get(KNOWLEDGE_API_URL, params=params, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    items = extract_items_from_json(data)
+
+    docs = []
+    for item in items:
+        docs.append({
+            "type": "knowledge",
+            "title": item.get("조문제목", "") or item.get("법령명", "") or item.get("title", "") or item.get("subject", "") or item.get("제목", ""),
+            "law_name": item.get("법령명", "") or item.get("law_name", "") or item.get("lawTitle", ""),
+            "article": item.get("조문번호", "") or item.get("article", "") or item.get("articleNum", ""),
+            "summary": (item.get("조문내용", "") or item.get("description", "") or item.get("summary", "") or item.get("설명", ""))[:120],
+            "content": item.get("조문내용", "") or item.get("description", "") or item.get("content", "") or item.get("설명", ""),
+            "source": "지능형 법령정보지식베이스",
+        })
+
+    print(f"[knowledge] query='{query}' page={page} -> {len(docs)}개")
+    return docs
+
+
+def process_term(progress, start_id, existing_hashes):
+    query_index = progress["term"]["query_index"]
+    page = progress["term"]["page"]
+    current_id = start_id
+
+    for qi in range(query_index, len(TERM_QUERIES)):
+        query = TERM_QUERIES[qi]
+        current_page = page if qi == query_index else 1
+
+        while True:
+            docs = fetch_term_page(query, current_page)
+            if not docs:
+                break
+
+            current_id, inserted_count = upsert_docs(docs, "term", current_id, existing_hashes)
+
+            progress["term"]["query_index"] = qi
+            progress["term"]["page"] = current_page + 1
+            save_progress(progress)
+
+            if inserted_count == 0:
+                print(f"[term] query='{query}' page={current_page} 에서 신규 저장 0개 -> 다음 query로 이동")
+                break
+
+            current_page += 1
+
+        progress["term"]["query_index"] = qi + 1
+        progress["term"]["page"] = 1
+        save_progress(progress)
+
+    return current_id
+
+
+def process_knowledge(progress, start_id, existing_hashes):
+    query_index = progress["knowledge"]["query_index"]
+    page = progress["knowledge"]["page"]
+    current_id = start_id
+
+    for qi in range(query_index, len(KNOWLEDGE_QUERIES)):
+        query = KNOWLEDGE_QUERIES[qi]
+        current_page = page if qi == query_index else 1
+
+        while True:
+            docs = fetch_knowledge_page(query, current_page)
+            if not docs:
+                break
+
+            current_id, inserted_count = upsert_docs(docs, "knowledge", current_id, existing_hashes)
+
+            progress["knowledge"]["query_index"] = qi
+            progress["knowledge"]["page"] = current_page + 1
+            save_progress(progress)
+
+            if inserted_count == 0:
+                print(f"[knowledge] query='{query}' page={current_page} 에서 신규 저장 0개 -> 다음 query로 이동")
+                break
+
+            current_page += 1
+
+        progress["knowledge"]["query_index"] = qi + 1
+        progress["knowledge"]["page"] = 1
+        save_progress(progress)
+
+    return current_id
+
+
+def main():
+    progress = load_progress()
+    start_id = get_start_id()
+    existing_hashes = load_existing_hashes()
+
+    print("=== 현재 진행 상태 ===")
+    print(json.dumps(progress, ensure_ascii=False, indent=2))
+    print(f"\n=== 기존 중복 해시 개수 ===\n{len(existing_hashes)}")
+
+    print("\n법령용어(term) 적재 시작")
+    next_id = process_term(progress, start_id, existing_hashes)
+
+    print("\n지식베이스(knowledge) 적재 시작")
+    process_knowledge(progress, next_id, existing_hashes)
+
+    print("\n법령용어 + 지식베이스 적재 완료")
+
+
+if __name__ == "__main__":
+    main()

--- a/AI/rag/upsert_term_knowledge_from_api.py
+++ b/AI/rag/upsert_term_knowledge_from_api.py
@@ -1,11 +1,16 @@
 import os
 import sys
 import json
+<<<<<<< HEAD
+=======
+import time
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 import hashlib
 import requests
 from dotenv import load_dotenv
 from google import genai
 from google.genai import types
+<<<<<<< HEAD
 from qdrant_client.models import PointStruct
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -24,10 +29,31 @@ if not LAW_OC:
     raise RuntimeError("LAW_OC가 .env에 설정되어 있지 않습니다.")
 
 gemini_client = genai.Client(api_key=GEMINI_API_KEY)
+=======
+from fastembed import SparseTextEmbedding
+from qdrant_client.models import PointStruct, SparseVector
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+load_dotenv()
+
+from rag.db_utils import get_mongo_db, get_qdrant, LAW_COLLECTION, objectid_to_uuid
+
+LAW_OC = os.getenv("LAW_OC")
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+
+if not LAW_OC or not GEMINI_API_KEY:
+    raise RuntimeError("LAW_OC 또는 GEMINI_API_KEY가 설정되어 있지 않습니다.")
+
+gemini_client = genai.Client(api_key=GEMINI_API_KEY)
+bm25_model = SparseTextEmbedding(model_name="Qdrant/bm25")
+
+mongo_db = get_mongo_db()
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 qdrant = get_qdrant()
 
 TERM_API_URL = "https://www.law.go.kr/DRF/lawSearch.do"
 KNOWLEDGE_API_URL = "https://www.law.go.kr/DRF/lawSearch.do"
+<<<<<<< HEAD
 
 PROGRESS_FILE = os.path.join(os.path.dirname(__file__), "..", "data", "upsert_progress.json")
 
@@ -48,6 +74,29 @@ KNOWLEDGE_QUERIES = [
     "전대차",
     "묵시적 갱신",
     "위약금",
+=======
+MONGO_COLLECTION = "law_chunks"
+
+PROGRESS_FILE = os.path.join(os.path.dirname(__file__), "..", "data", "upsert_progress.json")
+
+DENSE_VECTOR_NAME = "dense"
+SPARSE_VECTOR_NAME = "sparse"
+
+TERM_QUERIES = [
+    "임대인", "임차인", "임대차", "보증금", "전세금", "차임", "월세", "전대차", "전차인",
+    "전세권", "묵시적 갱신", "계약갱신요구권", "계약 해지", "해지 통보", "손해배상",
+    "위약금", "해약금", "원상회복", "원상복구", "주택임대차보호법", "상가건물 임대차보호법",
+    "대항력", "우선변제권", "확정일자", "최우선변제", "전세사기", "임대보증금", "보증금 반환",
+    "임차권등기명령", "관리비", "중개수수료", "공인중개사", "특약", "계약기간", "갱신거절", "전입신고",
+]
+
+KNOWLEDGE_QUERIES = [
+    "임대차", "주택임대차", "상가임대차", "주택임대차보호법", "상가건물 임대차보호법", "보증금",
+    "보증금 반환", "임대보증금", "전세금", "월세", "차임", "계약갱신요구권", "묵시적 갱신",
+    "갱신거절", "계약 해지", "해지 통보", "손해배상", "위약금", "해약금", "전대차", "전차인",
+    "전세권", "대항력", "우선변제권", "확정일자", "최우선변제", "임차권등기명령", "원상회복",
+    "원상복구", "관리비", "중개수수료", "전입신고", "특약", "계약기간", "전세사기", "임대차 분쟁",
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 ]
 
 
@@ -68,6 +117,7 @@ def save_progress(progress):
         json.dump(progress, f, ensure_ascii=False, indent=2)
 
 
+<<<<<<< HEAD
 def embed_text(text: str) -> list[float]:
     result = gemini_client.models.embed_content(
         model="gemini-embedding-2-preview",
@@ -80,6 +130,41 @@ def embed_text(text: str) -> list[float]:
 def get_start_id() -> int:
     count_result = qdrant.count(collection_name=LAW_COLLECTION, exact=True)
     return count_result.count + 1
+=======
+def embed_dense(text: str, max_retries: int = 3) -> list[float]:
+    retry = 0
+    while True:
+        try:
+            result = gemini_client.models.embed_content(
+                model="gemini-embedding-2-preview",
+                contents=text,
+                config=types.EmbedContentConfig(task_type="RETRIEVAL_DOCUMENT"),
+            )
+            return result.embeddings[0].values
+        except Exception as e:
+            retry += 1
+            print(f"임베딩 실패 ({retry}회): {e}")
+
+            if "429" in str(e) or "RESOURCE_EXHAUSTED" in str(e):
+                wait_sec = min(30 * retry, 120)
+                print(f"임베딩 quota/rate 제한으로 {wait_sec}초 대기 후 재시도")
+                time.sleep(wait_sec)
+            else:
+                if retry >= max_retries:
+                    raise
+                time.sleep(3)
+
+            if retry >= max_retries:
+                raise
+
+
+def embed_sparse(text: str) -> SparseVector:
+    emb = next(iter(bm25_model.embed([text])))
+    return SparseVector(
+        indices=list(emb.indices),
+        values=list(emb.values),
+    )
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
 
 def make_embedding_input(doc: dict, doc_type: str) -> str:
@@ -99,9 +184,14 @@ def extract_items_from_json(data):
         return data
 
     if isinstance(data, dict):
+<<<<<<< HEAD
         for key, value in data.items():
             if isinstance(value, list):
                 print(f"응답에서 '{key}' 리스트를 찾았습니다. 개수: {len(value)}")
+=======
+        for _, value in data.items():
+            if isinstance(value, list):
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
                 return value
             elif isinstance(value, dict):
                 result = extract_items_from_json(value)
@@ -121,6 +211,7 @@ def make_unique_hash(doc: dict) -> str:
     return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
+<<<<<<< HEAD
 def load_existing_hashes() -> set[str]:
     existing_hashes = set()
     next_page_offset = None
@@ -148,10 +239,32 @@ def load_existing_hashes() -> set[str]:
 
         if next_page_offset is None:
             break
+=======
+def load_existing_hashes_from_mongo() -> set[str]:
+    col = mongo_db[MONGO_COLLECTION]
+    existing_hashes = set()
+
+    for doc in col.find(
+        {"type": {"$in": ["term", "knowledge"]}},
+        {"unique_hash": 1, "type": 1, "title": 1, "law_name": 1, "article": 1},
+    ):
+        if doc.get("unique_hash"):
+            existing_hashes.add(doc["unique_hash"])
+            continue
+
+        normalized = {
+            "type": doc.get("type", ""),
+            "title": doc.get("title", ""),
+            "law_name": doc.get("law_name", ""),
+            "article": doc.get("article", ""),
+        }
+        existing_hashes.add(make_unique_hash(normalized))
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
     return existing_hashes
 
 
+<<<<<<< HEAD
 def upsert_docs(docs: list[dict], doc_type: str, start_id: int, existing_hashes: set[str]):
     if not docs:
         print(f"{doc_type} 데이터가 없습니다.")
@@ -160,6 +273,49 @@ def upsert_docs(docs: list[dict], doc_type: str, start_id: int, existing_hashes:
     current_id = start_id
     inserted_count = 0
     skipped_count = 0
+=======
+def insert_doc_to_mongo(doc: dict):
+    return mongo_db[MONGO_COLLECTION].insert_one(doc).inserted_id
+
+
+def upsert_doc_to_qdrant(mongo_id, doc: dict, dense_vector: list[float], sparse_vector: SparseVector):
+    qdrant_id = objectid_to_uuid(mongo_id)
+
+    qdrant.upsert(
+        collection_name=LAW_COLLECTION,
+        points=[
+            PointStruct(
+                id=qdrant_id,
+                vector={
+                    DENSE_VECTOR_NAME: dense_vector,
+                    SPARSE_VECTOR_NAME: sparse_vector,
+                },
+                payload={
+                    "mongo_id": str(mongo_id),
+                    "type": doc.get("type", ""),
+                    "title": doc.get("title", ""),
+                    "law_name": doc.get("law_name", ""),
+                    "article": doc.get("article", ""),
+                    "summary": doc.get("summary", ""),
+                    "source": doc.get("source", ""),
+                    "unique_hash": doc.get("unique_hash", ""),
+                },
+            )
+        ],
+    )
+
+    return qdrant_id
+
+
+def save_docs_to_mongo_and_qdrant(docs: list[dict], doc_type: str, existing_hashes: set[str]) -> int:
+    if not docs:
+        print(f"{doc_type} 데이터가 없습니다.")
+        return 0
+
+    inserted_count = 0
+    skipped_count = 0
+    col = mongo_db[MONGO_COLLECTION]
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
     for idx, doc in enumerate(docs, start=1):
         try:
@@ -172,6 +328,7 @@ def upsert_docs(docs: list[dict], doc_type: str, start_id: int, existing_hashes:
                 continue
 
             doc["unique_hash"] = unique_hash
+<<<<<<< HEAD
 
             text = make_embedding_input(doc, doc_type)
             vector = embed_text(text)
@@ -185,19 +342,42 @@ def upsert_docs(docs: list[dict], doc_type: str, start_id: int, existing_hashes:
                         payload=doc,
                     )
                 ],
+=======
+            doc["process_status"] = "PENDING"
+
+            mongo_id = insert_doc_to_mongo(doc)
+
+            text = make_embedding_input(doc, doc_type)
+            dense_vector = embed_dense(text)
+            sparse_vector = embed_sparse(text)
+
+            qdrant_id = upsert_doc_to_qdrant(mongo_id, doc, dense_vector, sparse_vector)
+
+            col.update_one(
+                {"_id": mongo_id},
+                {"$set": {"process_status": "DONE", "qdrant_id": qdrant_id}},
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
             )
 
             existing_hashes.add(unique_hash)
             inserted_count += 1
 
+<<<<<<< HEAD
             print(f"{doc_type} 저장 완료: id={current_id}, title={doc.get('title', '')}")
             current_id += 1
+=======
+            print(f"{doc_type} 저장 완료: mongo_id={mongo_id}, qdrant_id={qdrant_id}, title={doc.get('title', '')}")
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
         except Exception as e:
             print(f"{doc_type} 업로드 실패 ({idx}번째): {e}")
 
     print(f"{doc_type} 업로드 완료: 신규 {inserted_count}개, 중복 스킵 {skipped_count}개")
+<<<<<<< HEAD
     return current_id, inserted_count
+=======
+    return inserted_count
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
 
 def fetch_term_page(query: str, page: int) -> list[dict]:
@@ -206,7 +386,11 @@ def fetch_term_page(query: str, page: int) -> list[dict]:
         "target": "lstrmAI",
         "type": "JSON",
         "query": query,
+<<<<<<< HEAD
         "display": 20,
+=======
+        "display": 100,
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
         "page": page,
     }
 
@@ -239,7 +423,11 @@ def fetch_knowledge_page(query: str, page: int) -> list[dict]:
         "type": "JSON",
         "search": 0,
         "query": query,
+<<<<<<< HEAD
         "display": 20,
+=======
+        "display": 100,
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
         "page": page,
     }
 
@@ -265,10 +453,16 @@ def fetch_knowledge_page(query: str, page: int) -> list[dict]:
     return docs
 
 
+<<<<<<< HEAD
 def process_term(progress, start_id, existing_hashes):
     query_index = progress["term"]["query_index"]
     page = progress["term"]["page"]
     current_id = start_id
+=======
+def process_term(progress, existing_hashes):
+    query_index = progress["term"]["query_index"]
+    page = progress["term"]["page"]
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
     for qi in range(query_index, len(TERM_QUERIES)):
         query = TERM_QUERIES[qi]
@@ -279,7 +473,11 @@ def process_term(progress, start_id, existing_hashes):
             if not docs:
                 break
 
+<<<<<<< HEAD
             current_id, inserted_count = upsert_docs(docs, "term", current_id, existing_hashes)
+=======
+            inserted_count = save_docs_to_mongo_and_qdrant(docs, "term", existing_hashes)
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
             progress["term"]["query_index"] = qi
             progress["term"]["page"] = current_page + 1
@@ -295,6 +493,7 @@ def process_term(progress, start_id, existing_hashes):
         progress["term"]["page"] = 1
         save_progress(progress)
 
+<<<<<<< HEAD
     return current_id
 
 
@@ -302,6 +501,12 @@ def process_knowledge(progress, start_id, existing_hashes):
     query_index = progress["knowledge"]["query_index"]
     page = progress["knowledge"]["page"]
     current_id = start_id
+=======
+
+def process_knowledge(progress, existing_hashes):
+    query_index = progress["knowledge"]["query_index"]
+    page = progress["knowledge"]["page"]
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
     for qi in range(query_index, len(KNOWLEDGE_QUERIES)):
         query = KNOWLEDGE_QUERIES[qi]
@@ -312,7 +517,11 @@ def process_knowledge(progress, start_id, existing_hashes):
             if not docs:
                 break
 
+<<<<<<< HEAD
             current_id, inserted_count = upsert_docs(docs, "knowledge", current_id, existing_hashes)
+=======
+            inserted_count = save_docs_to_mongo_and_qdrant(docs, "knowledge", existing_hashes)
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
             progress["knowledge"]["query_index"] = qi
             progress["knowledge"]["page"] = current_page + 1
@@ -328,6 +537,7 @@ def process_knowledge(progress, start_id, existing_hashes):
         progress["knowledge"]["page"] = 1
         save_progress(progress)
 
+<<<<<<< HEAD
     return current_id
 
 
@@ -347,6 +557,24 @@ def main():
     process_knowledge(progress, next_id, existing_hashes)
 
     print("\n법령용어 + 지식베이스 적재 완료")
+=======
+
+def main():
+    progress = load_progress()
+    existing_hashes = load_existing_hashes_from_mongo()
+
+    print("=== 현재 진행 상태 ===")
+    print(json.dumps(progress, ensure_ascii=False, indent=2))
+    print(f"\n=== 기존 MongoDB 중복 해시 개수 ===\n{len(existing_hashes)}")
+
+    print("\n법령용어(term) 적재 시작")
+    process_term(progress, existing_hashes)
+
+    print("\n지식베이스(knowledge) 적재 시작")
+    process_knowledge(progress, existing_hashes)
+
+    print("\n법령용어 + 지식베이스 MongoDB + Qdrant 적재 완료")
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
 
 if __name__ == "__main__":

--- a/AI/requirements.txt
+++ b/AI/requirements.txt
@@ -1,7 +1,7 @@
 google-genai
 python-dotenv==1.0.0
 pytesseract==0.3.10
-pillow==10.1.0
+pillow==11.0.0
 pdfplumber
 fastapi
 uvicorn

--- a/AI/requirements.txt
+++ b/AI/requirements.txt
@@ -1,7 +1,11 @@
 google-genai
 python-dotenv==1.0.0
 pytesseract==0.3.10
+<<<<<<< HEAD
 pillow==11.0.0
+=======
+pillow>=10.1.0
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 pdfplumber
 fastapi
 uvicorn
@@ -9,3 +13,5 @@ python-multipart
 httpx
 pymongo
 qdrant-client
+fastembed
+requests

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -12,8 +12,18 @@ import resultRouter from './routes/result_routes.js';
 import authRouter from './routes/auth_routes.js';
 import chatRouter from './routes/chat_routes.js';
 
+<<<<<<< HEAD
 import swaggerSpec from './swagger/swagger.js';
 import { connect } from './schemas/index.js';
+=======
+import uploadRouter from "./routes/upload_routes.js";
+import analyzeRouter from "./routes/analyze_routes.js";
+import resultRouter from "./routes/result_routes.js";
+import authRouter from "./routes/auth_routes.js";
+import postRouter from "./routes/post_routes.js";
+import mypageRouter from "./routes/mypage_routes.js";
+import chatRouter from "./routes/chat_routes.js";
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
 dotenv.config();
 
@@ -53,7 +63,17 @@ app.use(session({
   }
 }));
 
+<<<<<<< HEAD
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+=======
+app.use("/api", authRouter);
+app.use("/api", uploadRouter);
+app.use("/api", analyzeRouter);
+app.use("/api", resultRouter);
+app.use("/api", chatRouter);
+app.use("/api/posts", postRouter);
+app.use("/api/mypage", mypageRouter);
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
 app.get('/', (req, res) => {
   res.json({ msg: 'AI Legal Doctor Backend OK' });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,82 +1,86 @@
-import express from "express";
-import cookieParser from "cookie-parser";
-import morgan from "morgan";
-import session from "express-session";
-import cors from "cors";
-import dotenv from "dotenv";
-import swaggerUi from "swagger-ui-express";
-import swaggerSpec from "./swagger/swagger.js";
+import express from 'express';
+import morgan from 'morgan';
+import session from 'express-session';
+import cookieParser from 'cookie-parser';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import swaggerUi from 'swagger-ui-express';
 
-import { connect } from "./schemas/index.js";
+import uploadRouter from './routes/upload_routes.js';
+import analyzeRouter from './routes/analyze_routes.js';
+import resultRouter from './routes/result_routes.js';
+import authRouter from './routes/auth_routes.js';
+import chatRouter from './routes/chat_routes.js';
+
+import swaggerSpec from './swagger/swagger.js';
+import { connect } from './schemas/index.js';
 
 dotenv.config();
 
-import uploadRouter from "./routes/upload_routes.js";
-import analyzeRouter from "./routes/analyze_routes.js";
-import resultRouter from "./routes/result_routes.js";
-import authRouter from "./routes/auth_routes.js";
-
 const app = express();
 app.set('port', process.env.PORT || 3001);
+
 connect();
 
 app.use(morgan('dev'));
 
 app.use((req, res, next) => {
-    res.setTimeout(120000, () => {
-        res.status(408).json({ message: "요청 시간이 초과되었습니다." });
-    });
-    next();
+  res.setTimeout(120000, () => {
+    res.status(408).json({ message: '요청 시간이 초과되었습니다.' });
+  });
+  next();
 });
 
 app.use(cors({
-    origin: [
-        "http://localhost:5173",  // 로컬 개발
-        "http://localhost",       // Docker 프로덕션
-    ],
-    credentials: true
+  origin: [
+    'http://localhost:5173',
+    'http://localhost',
+  ],
+  credentials: true,
 }));
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser(process.env.COOKIE_SECRET));
+
 app.use(session({
-    resave: false,
-    saveUninitialized: false,
-    secret: process.env.COOKIE_SECRET,
-    cookie: {
-        httpOnly: true,
-        secure: false,
-    }
+  resave: false,
+  saveUninitialized: false,
+  secret: process.env.COOKIE_SECRET || 'secret',
+  cookie: {
+    httpOnly: true,
+    secure: false,
+  }
 }));
-app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+app.get('/', (req, res) => {
+  res.json({ msg: 'AI Legal Doctor Backend OK' });
+});
 
 app.use('/api', uploadRouter);
 app.use('/api', analyzeRouter);
 app.use('/api', resultRouter);
+app.use('/api', chatRouter);
 app.use('/api/auth', authRouter);
 
-app.get('/', (req, res) => {
-    res.json({
-        msg: "AI Legal Doctor Backend OK",
-    });
-});
-
 app.use((req, res, next) => {
-    const error = new Error(`${req.method} ${req.url} 라우터가 없습니다.`);
-    error.status = 404;
-    next(error);
+  const error = new Error(`${req.method} ${req.url} 라우터가 없습니다.`);
+  error.status = 404;
+  next(error);
 });
+
 app.use((err, req, res, next) => {
-    console.error(err);
-
-    res.status(err.status || 500).json({
-        message: err.message,
-        error: process.env.NODE_ENV !== 'production' ? err : {}
-    });
+  console.error(err);
+  res.status(err.status || 500).json({
+    message: err.message,
+    error: process.env.NODE_ENV !== 'production' ? err : {},
+  });
 });
-
-
 
 app.listen(app.get('port'), () => {
-    console.log(app.get('port'), '번 포트에서 대기 중');
+  console.log(app.get('port'), '번 포트에서 대기 중');
 });
+
+export default app;

--- a/backend/src/routes/chat_routes.js
+++ b/backend/src/routes/chat_routes.js
@@ -2,6 +2,7 @@ import express from "express";
 import axios from "axios";
 
 const router = express.Router();
+<<<<<<< HEAD
 const AI_SERVER_URL = process.env.AI_SERVER_URL || "http://localhost:8000";
 
 router.post("/chat", async (req, res, next) => {
@@ -32,6 +33,24 @@ router.post("/chat", async (req, res, next) => {
   } catch (error) {
     console.error("❌ /api/chat 오류:", error?.response?.data || error.message);
     next(error);
+=======
+const AI_SERVER_URL = process.env.AI_SERVER_URL || "http://ai:8000";
+
+router.post("/chat", async (req, res) => {
+  try {
+    const response = await axios.post(`${AI_SERVER_URL}/api/chat`, req.body, {
+      headers: { "Content-Type": "application/json" },
+      timeout: 120000,
+    });
+
+    res.json(response.data);
+  } catch (error) {
+    console.error("챗봇 요청 오류:", error.response?.data || error.message);
+    res.status(500).json({
+      message: "챗봇 요청 중 오류가 발생했습니다.",
+      detail: error.response?.data || error.message,
+    });
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
   }
 });
 

--- a/backend/src/routes/chat_routes.js
+++ b/backend/src/routes/chat_routes.js
@@ -1,0 +1,38 @@
+import express from "express";
+import axios from "axios";
+
+const router = express.Router();
+const AI_SERVER_URL = process.env.AI_SERVER_URL || "http://localhost:8000";
+
+router.post("/chat", async (req, res, next) => {
+  try {
+    const { question } = req.body;
+
+    if (!question || typeof question !== "string") {
+      return res.status(400).json({
+        success: false,
+        message: "question 값이 필요합니다.",
+      });
+    }
+
+    const response = await axios.post(
+      `${AI_SERVER_URL}/api/chat`,
+      { question },
+      {
+        headers: { "Content-Type": "application/json" },
+        timeout: 120000,
+      }
+    );
+
+    return res.json({
+      success: true,
+      answer: response.data.answer,
+      references: response.data.references || {},
+    });
+  } catch (error) {
+    console.error("❌ /api/chat 오류:", error?.response?.data || error.message);
+    next(error);
+  }
+});
+
+export default router;

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3001/api";
 
 export interface ChatResponse {
@@ -32,3 +33,17 @@ export const chatAPI = {
     return data;
   },
 };
+=======
+import { apiClient } from "./client";
+
+export interface ChatResponse {
+  answer: string;
+}
+
+export async function sendChatMessage(question: string): Promise<ChatResponse> {
+  return apiClient<ChatResponse>("/api/chat", {
+    method: "POST",
+    body: JSON.stringify({ question }),
+  });
+}
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -1,0 +1,34 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3001/api";
+
+export interface ChatResponse {
+  success: boolean;
+  answer: string;
+  references?: {
+    terms?: any[];
+    knowledge?: any[];
+    laws?: any[];
+    interpretations?: any[];
+    cases?: any[];
+  };
+}
+
+export const chatAPI = {
+  async ask(question: string): Promise<ChatResponse> {
+    const response = await fetch(`${API_BASE_URL}/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify({ question }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.message || "챗봇 요청 실패");
+    }
+
+    return data;
+  },
+};

--- a/frontend/src/components/aidt/shared/Chatbot.tsx
+++ b/frontend/src/components/aidt/shared/Chatbot.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import ChatbotIcon from '../../../assets/img/ChatbotIcon.svg';
 import ChatbotAvatar from '../../../assets/img/ChatboAvatar.svg';
 import { RiSendPlane2Fill } from "react-icons/ri";
+import { chatAPI } from '../../../api/chat';
 import './Chatbot.css';
 
 interface Message {
@@ -9,13 +10,6 @@ interface Message {
   role: 'user' | 'bot';
   content: string;
 }
-
-// mock 응답 (나중에 실제 API로 교체)
-const getMockResponse = (input: string): string => {
-  if (input.includes('관리비')) return '관리비 관련 조항은 계약서 3조에 명시되어 있으며, 부당청구 시 관련 법령에 따라 이의를 제기할 수 있습니다.';
-  if (input.includes('계약')) return '계약 관련 내용은 민법 및 주택임대차보호법의 적용을 받습니다. 구체적인 조항을 확인해 드릴게요.';
-  return '해당 내용에 대해 분석 중입니다. 계약서의 관련 조항을 검토한 결과를 알려드릴게요.';
-};
 
 function Chatbot() {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -36,15 +30,29 @@ function Chatbot() {
     setInput('');
     setIsLoading(true);
 
-    setTimeout(() => {
+    try {
+      const result = await chatAPI.ask(text);
+
       const botMsg: Message = {
         id: Date.now() + 1,
         role: 'bot',
-        content: getMockResponse(text),
+        content: result.answer || '관련 정보를 찾을 수 없습니다.',
       };
+
       setMessages(prev => [...prev, botMsg]);
+    } catch (error) {
+      const botMsg: Message = {
+        id: Date.now() + 1,
+        role: 'bot',
+        content: error instanceof Error
+          ? `오류: ${error.message}`
+          : '오류: 챗봇 요청 중 문제가 발생했습니다.',
+      };
+
+      setMessages(prev => [...prev, botMsg]);
+    } finally {
       setIsLoading(false);
-    }, 800);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/frontend/src/components/aidt/shared/Chatbot.tsx
+++ b/frontend/src/components/aidt/shared/Chatbot.tsx
@@ -1,36 +1,47 @@
-import { useState, useRef, useEffect } from 'react';
-import ChatbotIcon from '../../../assets/img/ChatbotIcon.svg';
-import ChatbotAvatar from '../../../assets/img/ChatboAvatar.svg';
+import { useState, useRef, useEffect } from "react";
+import ChatbotIcon from "../../../assets/img/ChatbotIcon.svg";
+import ChatbotAvatar from "../../../assets/img/ChatboAvatar.svg";
 import { RiSendPlane2Fill } from "react-icons/ri";
+<<<<<<< HEAD
 import { chatAPI } from '../../../api/chat';
 import './Chatbot.css';
+=======
+import { sendChatMessage } from "../../../api/chat";
+import "./Chatbot.css";
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
 
 interface Message {
   id: number;
-  role: 'user' | 'bot';
+  role: "user" | "bot";
   content: string;
 }
 
 function Chatbot() {
   const [messages, setMessages] = useState<Message[]>([]);
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, isLoading]);
 
   const handleSend = async () => {
     const text = input.trim();
     if (!text || isLoading) return;
 
-    const userMsg: Message = { id: Date.now(), role: 'user', content: text };
-    setMessages(prev => [...prev, userMsg]);
-    setInput('');
+    const userMsg: Message = {
+      id: Date.now(),
+      role: "user",
+      content: text,
+    };
+
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
     setIsLoading(true);
 
     try {
+<<<<<<< HEAD
       const result = await chatAPI.ask(text);
 
       const botMsg: Message = {
@@ -50,18 +61,37 @@ function Chatbot() {
       };
 
       setMessages(prev => [...prev, botMsg]);
+=======
+      const result = await sendChatMessage(text);
+
+      const botMsg: Message = {
+        id: Date.now() + 1,
+        role: "bot",
+        content: result.answer || "응답이 없습니다.",
+      };
+
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (error: any) {
+      const errorMsg: Message = {
+        id: Date.now() + 1,
+        role: "bot",
+        content: `오류: ${error?.message || "챗봇 요청 실패"}`,
+      };
+
+      setMessages((prev) => [...prev, errorMsg]);
+>>>>>>> 993fa18 (feat: 챗봇 RAG 검색 및 법령/용어/지식베이스 연동 구현)
     } finally {
       setIsLoading(false);
     }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') handleSend();
+    if (e.key === "Enter") handleSend();
   };
 
   return (
     <div className="chatbot-container">
-      <div className={`chat-messages ${messages.length === 0 ? 'empty' : ''}`}>
+      <div className={`chat-messages ${messages.length === 0 ? "empty" : ""}`}>
         {messages.length === 0 ? (
           <div className="empty-state">
             <span className="empty-icon">
@@ -71,24 +101,38 @@ function Chatbot() {
           </div>
         ) : (
           <>
-            {messages.map(msg => (
+            {messages.map((msg) => (
               <div key={msg.id} className={`message-row ${msg.role}`}>
-                {msg.role === 'bot' && (
-                  <img src={ChatbotAvatar} alt="챗봇" className="bot-avatar" width={36} height={36} />
+                {msg.role === "bot" && (
+                  <img
+                    src={ChatbotAvatar}
+                    alt="챗봇"
+                    className="bot-avatar"
+                    width={36}
+                    height={36}
+                  />
                 )}
-                <div className={`message-bubble ${msg.role}`}>
-                  {msg.content}
-                </div>
+                <div className={`message-bubble ${msg.role}`}>{msg.content}</div>
               </div>
             ))}
+
             {isLoading && (
               <div className="message-row bot">
-                <img src={ChatbotAvatar} alt="챗봇" className="bot-avatar" width={36} height={36} />
+                <img
+                  src={ChatbotAvatar}
+                  alt="챗봇"
+                  className="bot-avatar"
+                  width={36}
+                  height={36}
+                />
                 <div className="message-bubble bot typing">
-                  <span /><span /><span />
+                  <span />
+                  <span />
+                  <span />
                 </div>
               </div>
             )}
+
             <div ref={messagesEndRef} />
           </>
         )}
@@ -100,10 +144,15 @@ function Chatbot() {
           placeholder="계약서 관련 질문을 입력해 주세요"
           className="chat-input"
           value={input}
-          onChange={e => setInput(e.target.value)}
+          onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
+          disabled={isLoading}
         />
-        <button className="send-btn" onClick={handleSend} disabled={!input.trim() || isLoading}>
+        <button
+          className="send-btn"
+          onClick={handleSend}
+          disabled={!input.trim() || isLoading}
+        >
           <RiSendPlane2Fill />
         </button>
       </div>


### PR DESCRIPTION
## 작업 내용
- 챗봇 응답 생성을 위한 `chatbot_analyzer.py` 추가
- Qdrant 데이터 상태 확인용 `check_qdrant.py` 추가
- 법령용어/지식베이스 API 적재 스크립트 추가
- 백엔드 챗봇 라우트 추가
- 프론트 챗봇 API 파일 추가
- 챗봇 연동을 위해 AI / backend / frontend 관련 파일 수정

## 주요 변경 파일
- `AI/analysis/chatbot_analyzer.py`  
  - 챗봇 질문을 받아 검색 결과를 기반으로 응답을 생성하는 분석 로직

- `AI/check_qdrant.py`  
  - Qdrant 컬렉션에 저장된 데이터 개수와 type별 분포를 확인하는 점검용 스크립트

- `AI/rag/upsert_term_knowledge_from_api.py`  
  - 법령용어 / 지식베이스 API 응답을 받아 Qdrant에 적재하는 스크립트  
  - 중복 저장 방지 및 중간 중단 후 이어서 적재하는 로직 포함

- `AI/ai_api.py`  
  - FastAPI 서버에 챗봇용 `/api/chat` 엔드포인트 추가 및 분석 로직 연결

- `AI/analysis/law_search.py`  
  - Qdrant 검색 결과를 챗봇에서 사용할 수 있도록 검색 / 분류 로직 보완

- `AI/requirements.txt`  
  - 챗봇 및 RAG 적재에 필요한 Python 패키지 의존성 반영

- `backend/src/routes/chat_routes.js`  
  - 프론트 요청을 AI 서버로 전달하는 백엔드 챗봇 라우트

- `backend/src/app.js`  
  - 챗봇 라우트를 백엔드 앱에 등록

- `frontend/src/api/chat.ts`  
  - 프론트에서 챗봇 API를 호출하기 위한 전용 API 모듈

- `frontend/src/components/aidt/shared/Chatbot.tsx`  
  - 챗봇 UI에서 실제 API 호출이 가능하도록 수정

## 확인 사항
- term / knowledge 데이터가 Qdrant에 저장되는 것 확인
- 챗봇 API 연결 구조 반영 확인
- Qdrant 적재 및 검색 확인
- 용어/지식베이스 중심 챗봇 테스트 가능 상태 확인

## 주의 사항
- `.env` 및 API 키 파일은 커밋하지 않음
- Gemini 임베딩 API quota 초과 시 적재가 중간에 멈출 수 있음
