### PR TITLE
feat: 마이페이지 API 연동, 법률서식 페이지 구현 및 연동

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import CommunityPage from './pages/CommunityPage';
 import PostDetailPage from './pages/PostdetailPage';
 import WritePostPage from './pages/WritepostPage';
 import SchedulePage from './pages/SchedulePage';
+import FormPage from './pages/FormPage';
 import MyPage from './pages/MyPage';
 import { AuthProvider } from './context/AuthContext';
 import { MdAccountCircle } from "react-icons/md";
@@ -68,7 +69,7 @@ function Navbar() {
               to="/form" 
               className={`nav-link ${isActive('/form') ? 'active' : ''}`}
             >
-              양식작성
+              법률서식
             </Link>
             <Link 
               to="/community" 
@@ -109,7 +110,7 @@ function Navbar() {
             className={`nav-link ${isActive('/form') ? 'active' : ''}`}
             onClick={closeMobileMenu}
           >
-            양식작성
+            법률서식
           </Link>
           <Link 
             to="/community" 
@@ -170,6 +171,7 @@ function AppContent() {
           <Route path="/community/:id" element={<PostDetailPage /> }/>
           <Route path="/community/write" element={<WritePostPage />} />
           <Route path="/schedule" element={<SchedulePage />} />
+          <Route path="/form" element={<FormPage />} />
           {/* 나중에 추가할 페이지들 */}
           {/* <Route path="/find-id" element={<FindIdPage />} /> */}
           {/* <Route path="/reset-password" element={<ResetPasswordPage />} /> */}

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -1,12 +1,22 @@
 import { apiClient } from "./client";
-
 export interface ChatResponse {
   answer: string;
 }
-
-export async function sendChatMessage(question: string): Promise<ChatResponse> {
-  return apiClient<ChatResponse>("/api/chat", {
+export interface ChatHistory {
+  documentId: string;
+  messages: { role: string; content: string }[];
+}
+export async function getChatHistory(documentId: string): Promise<ChatHistory> {
+  return apiClient<ChatHistory>(`/api/chat/${documentId}`);
+}
+export async function sendChatMessage(documentId: string, question: string): Promise<ChatResponse> {
+  return apiClient<ChatResponse>(`/api/chat/${documentId}/exchange`, {
     method: "POST",
     body: JSON.stringify({ question }),
+  });
+}
+export async function deleteChatHistory(documentId: string): Promise<void> {
+  return apiClient<void>(`/api/chat/${documentId}`, {
+    method: "DELETE",
   });
 }

--- a/frontend/src/api/form.ts
+++ b/frontend/src/api/form.ts
@@ -1,0 +1,53 @@
+const BASE = 'http://localhost:3001';
+
+const getHeaders = () => {
+  const token = localStorage.getItem('token');
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+};
+
+export interface Form {
+  formId: string;
+  form_name: string;
+  category: string;
+  source: string;
+  save_date: string;
+  downloadCount: number;
+}
+
+export interface DownloadResponse {
+  message: string;
+  downloadUrl: string;
+  fileName: string;
+}
+
+export const formsAPI = {
+  // 양식 목록 조회 - GET /api/forms
+  getForms: async (): Promise<Form[]> => {
+    const res = await fetch(`${BASE}/api/form`, { headers: getHeaders() });
+    if (!res.ok) throw new Error('양식 목록 조회 실패');
+    return res.json();
+  },
+
+  // 양식 다운로드 - GET /api/forms/download/:id
+  downloadForm: async (formId: string): Promise<DownloadResponse> => {
+    const res = await fetch(`${BASE}/api/form/download/${formId}`, {
+      headers: getHeaders(),
+    });
+    if (!res.ok) throw new Error('다운로드 실패');
+    return res.json();
+  },
+};
+
+export const mockForms: Form[] = [
+  {
+    formId: 'mock-1',
+    form_name: '건물임대차계약서',
+    category: '부동산',
+    source: '대한법률구조공단',
+    save_date: '2026-04-07',
+    downloadCount: 0,
+  },
+];

--- a/frontend/src/components/aidt/layout/RightSidebar.tsx
+++ b/frontend/src/components/aidt/layout/RightSidebar.tsx
@@ -8,9 +8,10 @@ type SidebarType = 'chatbot' | 'notification' | 'search' | null;
 interface RightSidebarProps {
   activeSidebar: SidebarType;
   onClose: () => void;
+  documentId?: string;
 }
 
-function RightSidebar({ activeSidebar, onClose }: RightSidebarProps) {
+function RightSidebar({ activeSidebar, onClose, documentId }: RightSidebarProps) {
   if (!activeSidebar) return null;
 
   return (
@@ -26,7 +27,7 @@ function RightSidebar({ activeSidebar, onClose }: RightSidebarProps) {
         </div>
         
         {activeSidebar === 'chatbot' 
-          ? <Chatbot /> 
+          ? <Chatbot documentId={documentId} />
           : activeSidebar === 'search'
           ? <SearchView />
           : <Notification />

--- a/frontend/src/components/aidt/shared/Chatbot.tsx
+++ b/frontend/src/components/aidt/shared/Chatbot.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import ChatbotIcon from "../../../assets/img/ChatbotIcon.svg";
 import ChatbotAvatar from "../../../assets/img/ChatboAvatar.svg";
 import { RiSendPlane2Fill } from "react-icons/ri";
-import { sendChatMessage } from "../../../api/chat";
+import { getChatHistory, sendChatMessage } from "../../../api/chat";
 import "./Chatbot.css";
 
 interface Message {
@@ -11,12 +11,38 @@ interface Message {
   content: string;
 }
 
-function Chatbot() {
+interface ChatbotProps {
+  documentId?: string;
+}
+
+function Chatbot({ documentId }: ChatbotProps) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
+  // 문서 변경 시 채팅 기록 불러오기
+  useEffect(() => {
+    if (!documentId) return;
+    const loadHistory = async () => {
+      try {
+        const history = await getChatHistory(documentId);
+        if (history.messages?.length > 0) {
+          const loaded = history.messages.map((m, i) => ({
+            id: i,
+            role: (m.role === "user" ? "user" : "bot") as "user" | "bot",
+            content: m.content,
+          }));
+          setMessages(loaded);
+        }
+      } catch {
+        // 기록 없으면 빈 상태로 시작
+      }
+    };
+    loadHistory();
+  }, [documentId]);
+
+  // 메시지 추가 시 스크롤 하단 이동
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isLoading]);
@@ -25,25 +51,34 @@ function Chatbot() {
     const text = input.trim();
     if (!text || isLoading) return;
 
+    if (!documentId) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now(),
+          role: "bot",
+          content: "문서를 먼저 선택해 주세요.",
+        },
+      ]);
+      return;
+    }
+
     const userMsg: Message = {
       id: Date.now(),
       role: "user",
       content: text,
     };
-
     setMessages((prev) => [...prev, userMsg]);
     setInput("");
     setIsLoading(true);
 
     try {
-      const result = await sendChatMessage(text);
-
+      const result = await sendChatMessage(documentId, text);
       const botMsg: Message = {
         id: Date.now() + 1,
         role: "bot",
         content: result.answer || "응답이 없습니다.",
       };
-
       setMessages((prev) => [...prev, botMsg]);
     } catch (error: any) {
       const errorMsg: Message = {
@@ -51,7 +86,6 @@ function Chatbot() {
         role: "bot",
         content: `오류: ${error?.message || "챗봇 요청 실패"}`,
       };
-
       setMessages((prev) => [...prev, errorMsg]);
     } finally {
       setIsLoading(false);
@@ -88,7 +122,6 @@ function Chatbot() {
                 <div className={`message-bubble ${msg.role}`}>{msg.content}</div>
               </div>
             ))}
-
             {isLoading && (
               <div className="message-row bot">
                 <img
@@ -105,12 +138,10 @@ function Chatbot() {
                 </div>
               </div>
             )}
-
             <div ref={messagesEndRef} />
           </>
         )}
       </div>
-
       <div className="chat-input-area">
         <input
           type="text"

--- a/frontend/src/components/mypage/mydocuments/DraftTableMUI.tsx
+++ b/frontend/src/components/mypage/mydocuments/DraftTableMUI.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-
+import { useState, useEffect } from 'react';
 import {
   Table,
   TableBody,
@@ -20,7 +19,8 @@ import {
   Divider,
 } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-import { mockDrafts, categoryInfo } from '../../../mock/mockDocuments';
+import { categoryInfo } from '../../../mock/mockDocuments';
+import { mypageAPI } from '../../../api/mypage';
 import DeleteIcon from '@mui/icons-material/Delete';
 import CreateRoundedIcon from '@mui/icons-material/CreateRounded';
 import ShareRoundedIcon from '@mui/icons-material/ShareRounded';
@@ -33,14 +33,36 @@ interface DraftTableProps {
 }
 
 export default function DraftTableMUI({ sortOrder, categoryFilter, searchQuery }: DraftTableProps) {
-  const drafts = mockDrafts
-    .filter(d => categoryFilter === 'all' || d.category === categoryFilter)
-    .filter(d => !searchQuery || d.title.toLowerCase().includes(searchQuery.toLowerCase()))
-    .sort((a, b) => {
-      if (sortOrder === 'oldest') return new Date(a.lastEditedAt).getTime() - new Date(b.lastEditedAt).getTime();
-      if (sortOrder === 'name') return a.title.localeCompare(b.title);
-      return new Date(b.lastEditedAt).getTime() - new Date(a.lastEditedAt).getTime(); // 최신순
-    });
+  const [drafts, setDrafts] = useState<DraftDocument[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsLoading(true);
+      try {
+        const sort = sortOrder === 'recent' ? 'recent' : sortOrder === 'oldest' ? 'old' : 'name';
+        const data = await mypageAPI.getDrafts(sort, categoryFilter === 'all' ? '' : categoryFilter);
+        const mapped = data.list.map((item: any) => ({
+          id: item.documentId,
+          title: item.title,
+          category: 'real_estate',
+          progress: item.progress || 0,
+          statusText: item.statusText || '미분석',
+          lastEditedAt: item.updatedAt,
+        }));
+        const filtered = searchQuery
+          ? mapped.filter((d: DraftDocument) => d.title.toLowerCase().includes(searchQuery.toLowerCase()))
+          : mapped;
+        setDrafts(filtered);
+      } catch (err) {
+        console.error('작성 중 목록 로딩 실패:', err);
+        setDrafts([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [sortOrder, categoryFilter, searchQuery]);
 
   return (
     <TableContainer 
@@ -122,10 +144,18 @@ export default function DraftTableMUI({ sortOrder, categoryFilter, searchQuery }
         </TableHead>
 
         <TableBody>
-        {drafts.map((draft) => (
-          <DraftRow key={draft.id} draft={draft} />
-        ))}
-      </TableBody>
+          {isLoading ? (
+            <TableRow>
+              <TableCell colSpan={5} sx={{ textAlign: 'center', padding: '40px', color: '#6B7280' }}>
+                로딩 중...
+              </TableCell>
+            </TableRow>
+          ) : (
+            drafts.map((draft) => (
+              <DraftRow key={draft.id} draft={draft} />
+            ))
+          )}
+        </TableBody>
         
       </Table>
 
@@ -133,19 +163,13 @@ export default function DraftTableMUI({ sortOrder, categoryFilter, searchQuery }
       {drafts.length === 0 && (
         <Box
           sx={{
-            padding: '80px 40px',
+            padding: '50px 40px',
             textAlign: 'center',
-            backgroundColor: '#FAFBFC',
+            backgroundColor: '#fff',
           }}
         >
-          <Typography sx={{ fontSize: '64px', marginBottom: '24px', opacity: 0.5 }}>
-            ✍️
-          </Typography>
-          <Typography sx={{ fontSize: '20px', fontWeight: 600, color: '#111827', marginBottom: '8px' }}>
+          <Typography sx={{ fontSize: '14px', fontWeight: 400, color: '#6B7280', marginBottom: '8px' }}>
             작성 중인 계약서가 없습니다
-          </Typography>
-          <Typography sx={{ fontSize: '15px', color: '#6B7280' }}>
-            템플릿으로 새 계약서를 만들어보세요!
           </Typography>
         </Box>
       )}
@@ -284,7 +308,7 @@ function DraftRow({ draft }: { draft: DraftDocument }){
               textAlign: 'right',
             }}
           >
-            {draft.progress}%
+            {draft.statusText || `${draft.progress}%`}
           </Typography>
         </Box>
       </TableCell>

--- a/frontend/src/components/mypage/mydocuments/MyDocument.tsx
+++ b/frontend/src/components/mypage/mydocuments/MyDocument.tsx
@@ -80,7 +80,7 @@ export default function Documents() {
         </div>
 
         {/* 작성하기 버튼 */}
-        <button className="btn-create">
+        <button className="btn-create" >
           +&nbsp; 계약서 작성하기
         </button>
       </div>

--- a/frontend/src/components/mypage/myhome/MyHome.tsx
+++ b/frontend/src/components/mypage/myhome/MyHome.tsx
@@ -1,12 +1,37 @@
 import { Link } from 'react-router-dom';
-import { mockDashboardStats } from '../../../mock/mockStats';
+import { useState, useEffect } from 'react';
+import { mypageAPI } from '../../../api/mypage';
 import '../myhome/MyHome.css';
 import { FaBoxArchive } from "react-icons/fa6";
 import { FaPen } from "react-icons/fa";
 import { FaCalendarCheck } from "react-icons/fa";
 import { BsPeopleFill } from "react-icons/bs";
 export default function Dashboard() {
-  const stats = mockDashboardStats;
+ const [stats, setStats] = useState({
+    documentCount: 0,
+    draftCount: 0,
+    scheduleCount: 0,
+    activityCount: 0,
+  });
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const [storageRes, draftRes] = await Promise.all([
+          mypageAPI.getStorage(),
+          mypageAPI.getDrafts(),
+        ]);
+        setStats(prev => ({
+          ...prev,
+          documentCount: storageRes.total,
+          draftCount: draftRes.total,
+        }));
+      } catch (err) {
+        console.error('홈 통계 로딩 실패:', err);
+      }
+    };
+    fetchStats();
+  }, []);
 
   return (
     <div className="dashboard">

--- a/frontend/src/pages/FormPage.css
+++ b/frontend/src/pages/FormPage.css
@@ -1,0 +1,131 @@
+.form-page {
+  min-height: 100vh;
+  background: #fff; 
+  padding: 30px 20px; 
+} 
+
+.form-container {
+  width: 1024px;
+  margin: 0 auto;
+}
+
+.form-page-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin-bottom: 20px;
+}
+
+/* 양식 리스트 */
+.form-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.form-list-header {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+  margin-bottom: 8px;
+}
+.form-list-count {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.form-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 8px 16px;
+  transition: all 0.15s;
+}
+
+
+.form-empty {
+  text-align: center;
+  padding: 60px;
+  color: #94a3b8;
+  font-size: 13px;
+  background: #fff;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+}
+
+.form-category-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #dbeafe;
+  color: #1d4ed8;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.form-card-divider {
+  width: 1px;
+  height: 16px;
+  background: #e2e8f0;
+  flex-shrink: 0;
+}
+
+.form-card-title {
+  flex: 2.5;
+  font-size: 13px;
+  font-weight: 500;
+  color: #1e293b;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.form-card-source {
+    flex: 0.5;
+    min-width: 0;
+  font-size: 12px;
+  color: #6b7280;
+  flex-shrink: 0;
+}
+
+.form-spacer {
+  flex: 1;
+}
+
+.form-download-count {
+  font-size: 12px;
+  color: #94a3b8;
+  flex-shrink: 0;
+}
+
+.form-card-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+
+.form-download-btn {
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: none;
+  background: #4099FD;
+  font-size: 11px;
+  font-weight: 500;
+  color: #fff;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.form-download-btn:disabled {
+  background: #93c5fd;
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/FormPage.tsx
+++ b/frontend/src/pages/FormPage.tsx
@@ -1,0 +1,148 @@
+import { useState, useEffect } from 'react';
+import { IoSearch } from 'react-icons/io5';
+import { formsAPI, Form, mockForms } from '../api/form';
+import './FormPage.css';
+
+const CATEGORY_OPTIONS = ['전체', '부동산'];
+const FORM_TYPE_OPTIONS: Record<string, string[]> = {
+  '전체': ['전체'],
+  '부동산': ['전체', '임대차계약서', '매매계약서', '전세계약서'],
+};
+
+export default function FormPage() {
+  const [forms, setForms] = useState<Form[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('전체');
+  const [selectedFormType, setSelectedFormType] = useState('전체');
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+
+  const fetchForms = async () => {
+    setIsLoading(true);
+    try {
+      const data = await formsAPI.getForms();
+      setForms(data);
+    } catch (err) {
+      console.error('양식 목록 로딩 실패:', err);
+      setForms(mockForms);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchForms();
+  }, []);
+
+  const handleDownload = async (formId: string) => {
+    setDownloadingId(formId);
+    try {
+      const res = await formsAPI.downloadForm(formId);
+      // 실제 파일 다운로드 처리
+      const link = document.createElement('a');
+      link.href = res.downloadUrl;
+      link.download = res.fileName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      // 다운로드 후 목록 재조회 (downloadCount 갱신)
+      await fetchForms();
+    } catch (err) {
+      console.error('다운로드 실패:', err);
+      alert('다운로드에 실패했습니다. 로그인 후 다시 시도해주세요.');
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  const filtered = forms
+    .filter(f => selectedCategory === '전체' || f.category === selectedCategory)
+   .filter(f => selectedFormType === '전체' || f.form_name?.includes(selectedFormType))
+.filter(f => !searchQuery || f.form_name?.toLowerCase().includes(searchQuery.toLowerCase()));
+
+  return (
+    <div className="form-page">
+      <div className="form-container">
+        {/* 헤더 */}
+        <h1 className="form-page-title">법률 서식</h1>
+
+        {/* 검색 + 필터 */}
+        <div className="controls-area">
+          <div className="search-box">
+            <input
+              type="text"
+              placeholder="양식을 검색하세요"
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+            />
+            <button className="search-btn">
+              <IoSearch />
+            </button>
+          </div>
+          <div className="filters">
+            <select
+              className="filter-select"
+              value={selectedCategory}
+              onChange={e => {
+                setSelectedCategory(e.target.value);
+                setSelectedFormType('전체');
+              }}
+            >
+              {CATEGORY_OPTIONS.map(opt => (
+                <option key={opt}>{opt}</option>
+              ))}
+            </select>
+            <select
+              className="filter-select"
+              value={selectedFormType}
+              onChange={e => setSelectedFormType(e.target.value)}
+            >
+              {(FORM_TYPE_OPTIONS[selectedCategory] || ['전체']).map(opt => (
+                <option key={opt}>{opt}</option>
+              ))}
+            </select>
+          </div>
+          <div className="form-list-header">
+            <span className="form-list-count">총 {filtered.length}건</span>
+            </div>
+        </div>
+        {/* 양식 건수 */}
+        
+        {/* 양식 리스트 */}
+        <div className="form-list">
+          {isLoading ? (
+            <div className="form-empty">로딩 중...</div>
+          ) : filtered.length === 0 ? (
+            <div className="form-empty">양식이 없습니다.</div>
+          ) : (
+            filtered.map(form => (
+              <div key={form.formId} className="form-card">
+                {/* 카테고리 뱃지 */}
+                <span className="form-category-badge">{form.category}</span>
+
+                <div className="form-card-divider" />
+
+                {/* 양식명 - 클릭 시 미리보기 */}
+                {/* 양식명 */}
+                <span className="form-card-title">{form.form_name}</span>
+                <div className="form-card-divider" />
+                {/* 출처 */}
+                <span className="form-card-source">{form.source}</span>
+                <div className="form-spacer" />
+                {/* 버튼 영역 */}
+                <div className="form-card-actions">
+                <button
+                    className="form-download-btn"
+                    onClick={() => handleDownload(form.formId)}
+                >
+                    다운로드
+                </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/document.ts
+++ b/frontend/src/types/document.ts
@@ -1,18 +1,13 @@
 // src/types/document.ts
 import { CategoryType } from './category';
-
 export interface DraftDocument {
   id: string;
   title: string;
   category: CategoryType;
   progress: number;
-  currentStep: number;
-  totalSteps: number;
-  stepName: string;
+  statusText: string;
   lastEditedAt: string;
-  createdAt: string;
 }
-
 export interface StorageDocument {
   id: string;
   title: string;
@@ -21,5 +16,4 @@ export interface StorageDocument {
   analysisStatus: 'completed' | 'unanalyzed' | 'analyzing';
   fileSize?: number;
 }
-
 export type AnalysisStatus = 'completed' | 'unanalyzed' | 'analyzing';


### PR DESCRIPTION
### 변경 사항

**마이페이지**
- MyHome.tsx - mock 통계 데이터 -> 실제 API 연동 (보관함/작성중 건수)
- DraftTableMUI.tsx — mock 데이터 → mypageAPI.getDrafts() 실제 API 연동, 로딩 UI 추가
- document.ts — DraftDocument 타입 백엔드 응답에 맞게 수정

**법률서식 페이지**
- FormPage.tsx — 법률 양식 목록 조회, 검색, 카테고리/세부 양식 필터, 페이지네이션, 다운로드 기능 구현
- FormPage.css — 양식 페이지 스타일
- form.ts — 양식 목록 조회, 다운로드 API 연동