### PR TITLE
feat: 마스킹 하이라이팅, 큰 데스크톱 반응형, 커뮤니티 검색 개선

### DIFF
--- a/backend/src/controllers/post_controller.js
+++ b/backend/src/controllers/post_controller.js
@@ -137,10 +137,10 @@ export const getPosts = async (req, res, next) => {
     }
 
     if (keyword) {
-      filter.title = {
-        $regex: escapeRegExp(keyword),
-        $options: "i",
-      };
+      filter.$or = [
+        { title: { $regex: escapeRegExp(keyword), $options: "i" } },
+        { content: { $regex: escapeRegExp(keyword), $options: "i" } },
+      ];
     }
 
     const posts = await Post.find(filter).populate("userRef", "name").lean();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>법닥</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/aidt/layout/FloatingButtons.tsx
+++ b/frontend/src/components/aidt/layout/FloatingButtons.tsx
@@ -46,7 +46,7 @@ const buildContentFromSelected = (items: RiskItem[], selectedIds: string[]): str
       const clauseText = item.clauseText ?? item.description ?? '';
       const reason = item.reason ?? '';
       const lines = [
-        `${idx + 1}. [${SEVERITY_LABEL[severity] ?? severity}]`,
+        `[${SEVERITY_LABEL[severity] ?? severity}]`,
         clauseText ? `위험 조항: ${clauseText}` : '',
         reason ? `위험 원인: ${reason}` : '',
       ].filter(Boolean);

--- a/frontend/src/components/aidt/layout/RightSidebar.css
+++ b/frontend/src/components/aidt/layout/RightSidebar.css
@@ -68,3 +68,15 @@
     max-width: 350px;
   }
 }
+
+@media (min-width: 1600px) {
+  .right-sidebar {
+    width: 400px;
+  }
+}
+
+@media (min-width: 1800px) {
+  .right-sidebar {
+    width: 440px;
+  }
+}

--- a/frontend/src/components/aidt/layout/TopMenu.css
+++ b/frontend/src/components/aidt/layout/TopMenu.css
@@ -202,3 +202,20 @@
     display: none;
   }
 }
+@media (min-width: 1600px) {
+  
+  .menu-nav {
+    width: 1400px;
+    gap: 140px;
+  }
+}
+
+@media (min-width: 1800px) {
+  .top-menu.sidebar-open {
+    width: calc(100% - 450px);
+  }
+  .menu-nav {
+    width: 1600px;
+    gap: 160px;
+  }
+}

--- a/frontend/src/components/aidt/shared/SearchView.css
+++ b/frontend/src/components/aidt/shared/SearchView.css
@@ -241,6 +241,7 @@ margin: 0 auto;
   flex-wrap: wrap;
   gap: 10px;
   justify-content: center;
+  max-width: 320px;
 }
 
 .search-suggestion-btn {

--- a/frontend/src/components/aidt/views/DangerView.css
+++ b/frontend/src/components/aidt/views/DangerView.css
@@ -35,27 +35,25 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  gap: 6px; /* 아이콘과 텍스트 간격 */
 }
 
 .info-icon {
   cursor: pointer;
-  font-size: 1.3125em; 
+  font-size: 1.1em;
   color: #aaaaaa;
   user-select: none;
   display: flex;
   align-items: center;
+  line-height: 1; /* 줄 맞춤 */
   transition: transform 0.2s ease, color 0.2s ease;
-  animation: pulse 2s infinite; /* ← 클릭 유도 애니메이션 */
-}
-
-.info-icon:hover {
-  color: #666666;
+  animation: pulse 2s infinite;
 }
 
 .info-icon:hover {
   color: #555555;
   transform: scale(1.2);
-  animation: none; /* hover 시 pulse 멈춤 */
+  animation: none;
 }
 
 .info-icon.active {
@@ -66,15 +64,15 @@
 
 /* ── 클릭 유도 pulse 애니메이션 ── */
 @keyframes pulse {
-  0%   { transform: scale(1);    color: #aaaaaa; }
+  0%   { transform: scale(1);   color: #aaaaaa; }
   50%  { transform: scale(1.1); color: #555555; }
-  100% { transform: scale(1);    color: #aaaaaa; }
+  100% { transform: scale(1);   color: #aaaaaa; }
 }
 
 /* ── 가이드 팝업 ── */
 .risk-guide-content {
   position: absolute;
-  top: 20px;
+  top: 24px;
   left: 0;
   z-index: 200;
   background: #fff;
@@ -82,7 +80,7 @@
   border-radius: 12px;
   padding: 20px;
   width: 600px;
- box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
 }
 
 /* ── 위험도 가이드 목록 ── */
@@ -198,24 +196,51 @@
 .document-line.highlight-medium { background-color: #ff6c1d68; padding-left: 12px; margin: 5px 0; }
 .document-line.highlight-low    { background-color: #ffc82f7f; padding-left: 12px; margin: 8px 0; }
 
-/* ── 이유 박스 ── */
+/* ── 이유 박스 — 대응가이드와 통일된 스타일 ── */
 .reason-box {
   margin: 8px 0 20px 20px;
-  padding: 14px 18px;
-  border-radius: 10px;
-  border: 1px solid;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border-left: 3px solid transparent;
   line-height: 1.7;
 }
 
-.reason-box.severity-high   { background: #fff5f5;   border-color: #EA1C1C; }
-.reason-box.severity-medium { background: #fffbf0;   border-color: #FF6C1D; }
-.reason-box.severity-low    { background: #fcf5cf79; border-color: #FFC72F; }
+.reason-box.severity-high {
+  background: #fff5f5;
+  border: 1px solid #fecaca;
+}
+
+.reason-box.severity-medium {
+  background: #fff8f3;
+  border: 1px solid #fed7aa;
+
+}
+
+.reason-box.severity-low {
+  background: #fffdf0;
+  border: 1px solid #fde68a;
+
+}
 
 .reason-box .reason {
   font-size: 0.875em;
-  color: #DC2626;
+  color: #374151;
   line-height: 1.7;
+  margin: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
 }
+
+.warning-icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: inherit;
+}
+
+.reason-box.severity-high .reason   { color: #b91c1c; }
+.reason-box.severity-medium .reason { color: #c2410c; }
+.reason-box.severity-low .reason    { color: #92400e; }
 
 .reason-icon {
   vertical-align: middle;
@@ -256,55 +281,34 @@
 }
 
 /* 표 안 하이라이팅 */
-.danger-table-block mark.risk-highlight-high {
-  background-color: #ea1c1c56;
-  padding: 1px 3px;
-}
-
-.danger-table-block mark.risk-highlight-medium {
-  background-color: #ff6c1d68;
-  padding: 1px 3px;
-}
-
-.danger-table-block mark.risk-highlight-low {
-  background-color: #ffc82f7f;
-  padding: 1px 3px;
-}
+.danger-table-block mark.risk-highlight-high   { background-color: #ea1c1c56; padding: 1px 3px; }
+.danger-table-block mark.risk-highlight-medium { background-color: #ff6c1d68; padding: 1px 3px; }
+.danger-table-block mark.risk-highlight-low    { background-color: #ffc82f7f; padding: 1px 3px; }
 
 /* 키워드 매칭 실패 시 표 전체 테두리 */
-.danger-table-block.table-border-high {
-  border: 4px solid #ea1c1c6e;
-}
-
-.danger-table-block.table-border-medium {
-  border: 4px solid #ff6c1d68;
-}
-
-.danger-table-block.table-border-low {
-  border: 2px solid #FFC72F;
-}
+.danger-table-block.table-border-high   { border: 4px solid #ea1c1c6e; }
+.danger-table-block.table-border-medium { border: 4px solid #ff6c1d68; }
+.danger-table-block.table-border-low    { border: 2px solid #FFC72F; }
 
 /* 표 전체 하이라이팅 */
-.highlight-table-high   { background-color: #ea1c1c20; border: 2px solid #EA1C1C;}
-.highlight-table-medium { background-color: #ff6c1d20; border: 2px solid #FF6C1D;}
-.highlight-table-low    { background-color: #ffc82f20; border: 2px solid #FFC72F;}
+.highlight-table-high   { background-color: #ea1c1c20; border: 2px solid #EA1C1C; }
+.highlight-table-medium { background-color: #ff6c1d20; border: 2px solid #FF6C1D; }
+.highlight-table-low    { background-color: #ffc82f20; border: 2px solid #FFC72F; }
 
-.clause-table-box{
+.clause-table-box {
   margin: 8px 0;
 }
 
-.clause-table-box.severity-high   { background: #ea1c1c56;  }
+.clause-table-box.severity-high   { background: #ea1c1c56; }
 .clause-table-box.severity-medium { background: #ff6c1d68; }
-.clause-table-box.severity-low    { background: #ffc82f7f;}
-
+.clause-table-box.severity-low    { background: #ffc82f7f; }
 
 .clause-text {
   font-size: 0.875em;
   color: #333333;
-  line-height: 1.6;
+  line-height: 2;
   margin: 0;
   padding: 4px 8px;
-  line-height: 2;
 }
 
 .guide-toggle {
@@ -323,3 +327,14 @@
 .guide-toggle-btn.severity-high   { color: #EA1C1C; }
 .guide-toggle-btn.severity-medium { color: #FF6C1D; }
 .guide-toggle-btn.severity-low    { color: #FFC72F; }
+
+
+
+/* ── 반응형 ── */
+@media (min-width: 1600px) {
+  .dangerous-box { width: 960px; }
+}
+
+@media (min-width: 1800px) {
+  .dangerous-box { width: 1100px; }
+}

--- a/frontend/src/components/aidt/views/DangerView.tsx
+++ b/frontend/src/components/aidt/views/DangerView.tsx
@@ -2,7 +2,8 @@ import DocumentMeta from '../shared/DocumentMeta';
 import { RiskItem } from '../../../api/analyze';
 import { mockDocumentContent } from '../../../mock/mockData';
 import { useState, useMemo } from 'react';
-import { MdError } from "react-icons/md";
+import { MdError, MdWarning} from "react-icons/md";
+
 import "./DangerView.css"
 
 const normalizeRiskLevel = (level?: string): 'high' | 'medium' | 'low' => {
@@ -11,6 +12,10 @@ const normalizeRiskLevel = (level?: string): 'high' | 'medium' | 'low' => {
   if (normalized === 'medium') return 'medium';
   return 'low';
 };
+
+// 공백/줄바꿈 정규화 — 매칭 비교용
+const normalizeText = (text: string) =>
+  text.replace(/\s+/g, ' ').replace(/\u00A0/g, ' ').trim();
 
 interface DangerViewProps {
   currentDocument: {
@@ -34,13 +39,18 @@ function DangerView({
   editedHtml = '',
 }: DangerViewProps) {
 
+  // ── 블록 생성: 표는 그대로, 텍스트는 문단 단위로 ──
   const blocks = useMemo(() => {
-    const result: { type: 'table' | 'text'; content: string }[] = [];
+    const result: { type: 'table' | 'text'; content: string; rawText: string }[] = [];
     const html = editedHtml || '';
 
     if (!html) {
       const content = currentDocument.content || mockDocumentContent;
-      content.split('\n').forEach(line => result.push({ type: 'text', content: line }));
+      // 문단 단위로 분리
+      content.split(/\n{2,}/).forEach(para => {
+        const trimmed = para.trim();
+        if (trimmed) result.push({ type: 'text', content: para, rawText: normalizeText(trimmed) });
+      });
       return result;
     }
 
@@ -49,114 +59,138 @@ function DangerView({
     let match;
 
     while ((match = tableRegex.exec(html)) !== null) {
+      // 표 앞 텍스트 — 문단 단위로 분리
       if (match.index > lastIndex) {
         const div = document.createElement('div');
         div.innerHTML = html.slice(lastIndex, match.index);
-        const text = div.innerText || div.textContent || '';
-        text.split('\n').forEach(line => result.push({ type: 'text', content: line }));
+        // p 태그 기준으로 문단 분리
+        const paragraphs = div.querySelectorAll('p');
+        if (paragraphs.length > 0) {
+          paragraphs.forEach(p => {
+            const text = (p.innerText || p.textContent || '').trim();
+            if (text) result.push({ type: 'text', content: text, rawText: normalizeText(text) });
+          });
+        } else {
+          // p 태그 없으면 전체 텍스트를 빈 줄 기준으로 분리
+          const fullText = div.innerText || div.textContent || '';
+          fullText.split(/\n{2,}/).forEach(para => {
+            const trimmed = para.trim();
+            if (trimmed) result.push({ type: 'text', content: trimmed, rawText: normalizeText(trimmed) });
+          });
+        }
       }
 
+      // 표 처리
       const tableDiv = document.createElement('div');
       tableDiv.innerHTML = match[0];
       const tdCount = tableDiv.querySelectorAll('td').length;
+      const tableText = normalizeText(tableDiv.innerText || tableDiv.textContent || '');
 
       if (tdCount <= 1) {
         const tdEl = tableDiv.querySelector('td');
         if (tdEl) {
-          tdEl.querySelectorAll('p, br').forEach(el => {
-            if (el.tagName === 'BR') {
-              el.replaceWith('\n');
-            } else {
-              el.insertAdjacentText('afterend', '\n');
-            }
-          });
           const text = (tdEl.innerText || tdEl.textContent || '').trim();
-          text.split('\n')
-            .map(line => line.trim())
-            .filter(line => line.length > 0)
-            .forEach(line => result.push({ type: 'text', content: line }));
+          if (text) result.push({ type: 'text', content: text, rawText: normalizeText(text) });
         }
       } else {
-        result.push({ type: 'table', content: match[0] });
+        result.push({ type: 'table', content: match[0], rawText: tableText });
       }
 
       lastIndex = match.index + match[0].length;
     }
 
+    // 나머지 텍스트
     if (lastIndex < html.length) {
       const div = document.createElement('div');
       div.innerHTML = html.slice(lastIndex);
-      const text = div.innerText || div.textContent || '';
-      text.split('\n').forEach(line => result.push({ type: 'text', content: line }));
+      const paragraphs = div.querySelectorAll('p');
+      if (paragraphs.length > 0) {
+        paragraphs.forEach(p => {
+          const text = (p.innerText || p.textContent || '').trim();
+          if (text) result.push({ type: 'text', content: text, rawText: normalizeText(text) });
+        });
+      } else {
+        const fullText = div.innerText || div.textContent || '';
+        fullText.split(/\n{2,}/).forEach(para => {
+          const trimmed = para.trim();
+          if (trimmed) result.push({ type: 'text', content: trimmed, rawText: normalizeText(trimmed) });
+        });
+      }
     }
 
     return result;
   }, [editedHtml, currentDocument.content]);
 
-  const riskFirstAppearance = useMemo(() => {
-    const appearances = new Map<number, number>();
+  // ── 매칭: 정규화된 텍스트로 비교 ──
+ const riskFirstAppearance = useMemo(() => {
+  const appearances = new Map<number, number>();
+  const blockMatchCount = new Map<number, number>(); // 블록당 매칭 수 제한
 
-    riskData.forEach((risk: RiskItem, riskIdx: number) => {
-      const getMatchScore = (text: string, risk: RiskItem): number => {
-        const t = text.trim();
-        if (t.length < 5) return 0;
-        const clauseText = risk.clauseText?.trim() ?? '';
-        if (!clauseText) return 0;
-        if (t.includes(clauseText)) return 90;
-        const firstSentence = clauseText.split(/[,.。]/)[0].trim();
-        if (firstSentence.length > 5 && t.includes(firstSentence)) return 70;
-        if (clauseText.includes(t) && t.length > 10) return 50;
-        const words = clauseText.split(' ').filter(w => w.length > 3);
+  riskData.forEach((risk: RiskItem, riskIdx: number) => {
+    const clauseRaw = normalizeText(risk.clauseText?.trim() ?? '');
+    if (!clauseRaw) return;
+
+    const getMatchScore = (blockRawText: string): number => {
+      const t = blockRawText;
+      if (t.length < 5) return 0;
+      if (t.includes(clauseRaw)) return 100;
+      if (clauseRaw.includes(t) && t.length > 15) return 85;
+      const firstSentence = normalizeText(clauseRaw.split(/[,.。\n]/)[0]);
+      if (firstSentence.length > 8 && t.includes(firstSentence)) return 75;
+      const articleMatch = clauseRaw.match(/^(제\d+조|①|②|③|④|⑤|\d+\.)/);
+      if (articleMatch && t.includes(articleMatch[0])) {
+        const words = clauseRaw.split(' ').filter(w => w.length > 3);
         if (words.length === 0) return 0;
         const matchCount = words.filter(w => t.includes(w)).length;
         const ratio = matchCount / words.length;
-        return ratio >= 0.5 ? ratio * 40 : 0;
-      };
+        if (ratio >= 0.4) return 60 + ratio * 20;
+      }
+      const words = clauseRaw.split(' ').filter(w => w.length > 3);
+      if (words.length === 0) return 0;
+      const matchCount = words.filter(w => t.includes(w)).length;
+      const ratio = matchCount / words.length;
+      return ratio >= 0.5 ? ratio * 50 : 0;
+    };
 
-      let bestScore = 0;
-      let bestBlockIndex = -1;
+    let bestScore = 0;
+    let bestBlockIndex = -1;
 
-      blocks.forEach((block, blockIndex) => {
-        const text = block.type === 'table'
-          ? (() => {
-              const d = document.createElement('div');
-              d.innerHTML = block.content;
-              return (d.innerText || d.textContent || '').replace(/\n/g, ' ').replace(/\s+/g, ' ').trim();
-            })()
-          : block.content;
-
-        const score = getMatchScore(text, risk);
-        if (score > bestScore) {
-          bestScore = score;
-          bestBlockIndex = blockIndex;
-        }
-      });
-
-      if (bestBlockIndex >= 0 && bestScore >= 30) {
-        appearances.set(riskIdx, bestBlockIndex);
+    blocks.forEach((block, blockIndex) => {
+      // 한 블록에 최대 2개까지만 매칭 허용
+      if ((blockMatchCount.get(blockIndex) ?? 0) >= 2) return;
+      const score = getMatchScore(block.rawText);
+      // 점수가 낮은 경우 큰 블록(특약사항 등)에 매칭 방지
+      if (score < 70 && block.rawText.length > 200) return;
+      if (score > bestScore) {
+        bestScore = score;
+        bestBlockIndex = blockIndex;
       }
     });
 
-    return appearances;
-  }, [blocks, riskData]);
+    if (bestBlockIndex < 0 || bestScore < 25) {
+      const fallbackIndex = Math.floor((riskIdx / riskData.length) * blocks.length);
+      appearances.set(riskIdx, Math.min(fallbackIndex, blocks.length - 1));
+    } else {
+      appearances.set(riskIdx, bestBlockIndex);
+      blockMatchCount.set(bestBlockIndex, (blockMatchCount.get(bestBlockIndex) ?? 0) + 1);
+    }
+  });
 
-  const riskPositions = useMemo(() => {
-    return riskData.map((risk: RiskItem, index: number) => {
+  return appearances;
+}, [blocks, riskData]);
+ const riskPositions = useMemo(() => {
+  return riskData
+    .map((risk: RiskItem, index: number) => {
       const blockIndex = riskFirstAppearance.get(index);
-      if (blockIndex !== undefined) {
-        return {
-          ...risk,
-          position: Math.min((blockIndex / blocks.length) * 100, 97),
-          index,
-        };
-      }
+      if (blockIndex === undefined) return null; // 매칭 실패 제외
       return {
         ...risk,
-        position: (index / riskData.length) * 100,
+        position: Math.min((blockIndex / blocks.length) * 100, 97),
         index,
       };
-    });
-  }, [riskData, riskFirstAppearance, blocks.length]);
+    })
+    .filter(Boolean) as any[];
+}, [riskData, riskFirstAppearance, blocks.length]);
 
   const adjustedPositions = useMemo(() => {
     const MIN_GAP = 3;
@@ -192,7 +226,7 @@ function DangerView({
                 onMouseLeave={() => setIsGuideOpen(false)}
               />
             </span>
-            <p>{riskData.length}개의 위험 포인트를 찾았어요</p>
+            <p>{riskFirstAppearance.size}개의 위험 포인트를 찾았어요</p>
             {isGuideOpen && (
               <div className="risk-guide-content">
                 <div className="risk-level-guide">
@@ -315,10 +349,11 @@ function DangerView({
                 );
               }
 
+              // 텍스트 블록
               const line = block.content;
               const trimmedLine = line.trim();
 
-              if (trimmedLine.length < 10) {
+              if (trimmedLine.length < 5) {
                 return <p key={blockIndex} className="document-line">{line || '\u00A0'}</p>;
               }
 
@@ -352,7 +387,7 @@ function DangerView({
                     const level = normalizeRiskLevel(risk.riskLevel);
                     return (
                       <div id={`reason-box-${riskIdx}`} key={riskIdx} className={`reason-box severity-${level}`}>
-                        <p className="reason">⚠️ {risk.reason || risk.description}</p>
+                        <p className="reason"><MdWarning className="warning-icon" /> {risk.reason || risk.description}</p>
                       </div>
                     );
                   })}

--- a/frontend/src/components/aidt/views/DocumentEditor.css
+++ b/frontend/src/components/aidt/views/DocumentEditor.css
@@ -39,3 +39,10 @@
 .document-editor-content .ProseMirror p {
   margin: 6px 0;
 }
+.masked-text {
+  background-color: #fef08a;
+  color: #92400e;
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-weight: 600;
+}

--- a/frontend/src/components/aidt/views/DocumentEditor.tsx
+++ b/frontend/src/components/aidt/views/DocumentEditor.tsx
@@ -5,10 +5,10 @@ import TableRow from '@tiptap/extension-table-row';
 import TableCell from '@tiptap/extension-table-cell';
 import TableHeader from '@tiptap/extension-table-header';
 import { forwardRef, useImperativeHandle, useEffect } from 'react';
-import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
 import { SearchQuery, findNext } from 'prosemirror-search';
+import { Extension, Mark, mergeAttributes } from '@tiptap/core';
 import './DocumentEditor.css';
 
 export interface DocumentEditorRef {
@@ -23,6 +23,16 @@ interface Props {
 
 // 검색 하이라이팅 Extension
 const searchPluginKey = new PluginKey('search');
+
+const MaskedText = Mark.create({
+  name: 'maskedText',
+  parseHTML() {
+    return [{ tag: 'span.masked-text' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['span', mergeAttributes(HTMLAttributes, { class: 'masked-text' }), 0];
+  },
+});
 
 const createSearchExtension = (searchTerm: string) =>
   Extension.create({
@@ -73,6 +83,7 @@ const DocumentEditor = forwardRef<DocumentEditorRef, Props>(
     const editor = useEditor({
       extensions: [
         StarterKit,
+        MaskedText,
         Table.configure({ resizable: false }),
         TableRow,
         TableHeader,

--- a/frontend/src/components/aidt/views/GuideView.css
+++ b/frontend/src/components/aidt/views/GuideView.css
@@ -1,6 +1,6 @@
 /* ── 대응 가이드 ── */
 
-/* 팁 박스 래퍼 - absolute로 겹치게 */
+/* 팁 박스 래퍼 */
 .guide-tip-box-wrapper {
   position: relative;
   width: 794px;
@@ -13,11 +13,12 @@
   left: 0;
   z-index: 50;
   width: 794px;
-  background: #e3f2fd;
-  border: 1px solid #90caf9;
-  border-radius: 9px;
+  background: #f8fbff;
+  border: 1px solid #dbeafe;
+  border-radius: 8px;
   overflow: hidden;
   transition: all 0.3s ease;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.05);
 }
 
 /* 팁 헤더 */
@@ -33,7 +34,7 @@
 }
 
 .tip-header:hover {
-  background: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.6);
 }
 
 .tip-title-group {
@@ -43,28 +44,24 @@
 }
 
 .tip-title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
   font-size: 1em;
   font-weight: 700;
-  color: #1976d2;
+  color: #4099FD;
   margin: 0;
 }
 
 .tip-badge {
   padding: 3px 10px;
-  background: #1976d2;
+  background: #4099FD;
   color: white;
-  border-radius: 12px;
+  border-radius: 9999px;
   font-size: 0.75em;
   font-weight: 600;
 }
 
-/* 토글 아이콘 */
 .tip-toggle-icon {
   font-size: 0.75em;
-  color: #1976d2;
+  color: #4099FD;
   transition: transform 0.3s ease;
 }
 
@@ -89,7 +86,7 @@
 .tip-main-title {
   font-size: 0.875em;
   font-weight: 600;
-  color: #1565c0;
+  color: #4099FD;
   margin: 0 0 10px 0;
 }
 
@@ -110,7 +107,6 @@
   opacity: 0;
 }
 
-
 @keyframes fadeInUp {
   from { opacity: 0; transform: translateY(4px); }
   to   { opacity: 1; transform: translateY(0); }
@@ -120,7 +116,7 @@
   content: '✓';
   position: absolute;
   left: 0;
-  color: #1976d2;
+  color: #4099FD;
   font-weight: bold;
 }
 
@@ -133,7 +129,7 @@
 .guide-tips h4 {
   font-size: 0.8125em;
   font-weight: 600;
-  color: #1976d2;
+  color: #4099FD;
   margin: 0 0 10px 0;
 }
 
@@ -156,7 +152,7 @@
   content: '•';
   position: absolute;
   left: 0;
-  color: #1976d2;
+  color: #4099FD;
   font-weight: bold;
 }
 
@@ -170,7 +166,7 @@
 .guide-header {
   margin-bottom: 28px;
   padding-bottom: 16px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid #e2e8f0;
 }
 
 .guide-header h2 {
@@ -198,8 +194,8 @@
   align-items: center;
   gap: 6px;
   padding: 5px 12px;
-  background: #e3f2fd;
-  color: #1976d2;
+  background: #f1f5f9;
+  color: #64748b;
   border-radius: 16px;
   font-size: 0.75em;
   font-weight: 600;
@@ -214,7 +210,7 @@
 
 .improvement-item {
   background: #ffffff;
-  border: 1px solid #eeeeee;
+  border: 1px solid #e2e8f0;
   border-radius: 12px;
   padding: 22px;
 }
@@ -237,10 +233,11 @@
 .warning-icon { font-size: 1.125em; color: #EA1C1C; }
 .retouch-icon { font-size: 1.125em; color: #4caf50; }
 
-/* 조항 박스 */
+/* 조항 박스 — 원래 색상 유지 */
 .clause-box {
   padding: 10px 18px;
   margin-bottom: 14px;
+  border-radius: 6px;
 }
 
 .clause-box.original {
@@ -259,13 +256,6 @@
   background: #ffc82f62 !important;
 }
 
-.emend-box.improved {
-  background: #e8f5e9;
-  border: 1px solid #a4c3a6;
-  border-radius: 8px;
-  padding: 10px 18px;
-}
-
 .clause-box p {
   margin: 0;
   font-size: 0.875em;
@@ -273,212 +263,82 @@
   color: #333333;
 }
 
-.emend-box p {
-  margin: 0;
-  font-size: 0.875em;
-  line-height: 1.8;
-  color: #333333;
-
-}
-
 /* 체크 포인트 */
 .check-points {
-  padding: 8px 14px;
+  padding: 12px 14px;
   margin-bottom: 14px;
+  border-radius: 6px;
 }
 
 .check-title {
   font-size: 0.875em;
   font-weight: 600;
-  color: #ff9800;
-  margin: 0 0 6px 0;
+  color: #4099FD;
+  margin: 0 0 8px 0;
   display: flex;
   align-items: center;
   gap: 4px;
 }
 
 .check-point-item {
-  font-size: 0.75em;
-  color: #666666;
-  margin: 4px 0;
-  line-height: 1.6;
+  font-size: 0.8125em;
+  color: #475569;
+  margin: 5px 0;
+  line-height: 1.7;
 }
 
 .improved-clause-section {
   margin-top: 18px;
 }
 
-/* ── 대응 가이드 적용 버튼 ── */
+/* 개선된 조항 박스 */
+.emend-box.improved {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 6px;
+  padding: 12px 18px;
+}
+
+.emend-box p {
+  margin: 0;
+  font-size: 0.875em;
+  line-height: 1.8;
+  color: #333333;
+}
+
+/* ── 대응 가이드 적용 버튼 — fixed, 플로팅 버튼 바로 위 ── */
 .apply-guide-btn {
   position: absolute;
   bottom: 40px;
-  right: 120px;
+  left: 46%;
+  transform: translateX(calc(46% + 397px + 20px));
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px 14px;
+  gap: 8px;
+  padding: 10px 14px;
   background-color: #4099FD;
-  color: white;
+  color: #ffffff;
   border: none;
   border-radius: 8px;
   font-size: 0.875em;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
   z-index: 100;
+  box-shadow: 0 2px 8px rgba(64, 153, 253, 0.3);
+  white-space: nowrap;
 }
 
 .apply-guide-btn:hover {
   background-color: #2b87f0;
 }
 
+
 .apply-guide-btn .btn-icon {
-  font-size: 1.125em;
+  font-size: 1.2em;
 }
 
 /* ── 미리보기 모달 ── */
-.preview-modal-overlay {
-  position: fixed;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background-color: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: 20px;
-  backdrop-filter: blur(4px);
-}
-
-.preview-modal {
-  background: white;
-  border-radius: 12px;
-  width: 100%;
-  max-width: 900px;
-  max-height: 90vh;
-  display: flex;
-  flex-direction: column;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
-  animation: modalSlideUp 0.3s ease;
-}
-
-@keyframes modalSlideUp {
-  from { opacity: 0; transform: translateY(30px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-.preview-modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 16px 24px;
-  border-bottom: 2px solid #f0f0f0;
-}
-
-.modal-title-group h2 {
-  margin: 0 0 4px 0;
-  font-size: 1.25em;
-  font-weight: 700;
-  color: #111111;
-}
-
-.modal-subtitle {
-  font-size: 0.8125em;
-  color: #888888;
-}
-
-.modal-close-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: #999;
-  padding: 4px;
-  display: flex;
-  align-items: center;
-  border-radius: 50%;
-  transition: all 0.2s;
-}
-
-.modal-close-btn:hover {
-  background-color: #f5f5f5;
-  color: #333;
-}
-
-.preview-modal-body {
-  flex: 1;
-  background: #f5f5f5;
-  padding: 40px 20px;
-  overflow-y: auto;
-  max-height: calc(100vh - 200px);
-}
-
-.preview-content {
-  background: white;
-  padding: 60px 80px;
-  min-height: 600px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  border: 1px solid #e0e0e0;
-  margin: 20px auto;
-  max-width: 800px;
-  overflow-x: auto;
-}
-
-.preview-content pre {
-  font-family: 'Malgun Gothic', '맑은 고딕', 'Noto Sans KR', sans-serif;
-  font-size: 11pt;
-  line-height: 1.8;
-  color: #111111;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  margin: 0;
-  padding: 0;
-}
-
-.preview-modal-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: 12px;
-  padding: 15px 28px;
-  border-top: 2px solid #f0f0f0;
-  background-color: #fafafa;
-  border-radius: 0 0 12px 12px;
-}
-
-.modal-cancel-btn,
-.modal-save-btn {
-  padding: 10px 22px;
-  border-radius: 8px;
-  font-size: 0.875em;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.modal-cancel-btn {
-  background-color: white;
-  border: 1px solid #ddd;
-  color: #666;
-}
-
-.modal-cancel-btn:hover {
-  background-color: #f8f9fa;
-}
-
-.modal-save-btn {
-  background-color: #4099FD;
-  border: none;
-  color: white;
-}
-
-.modal-save-btn:hover {
-  box-shadow: 0 4px 12px rgba(25, 118, 210, 0.3);
-}
-
-
-
-/* 모달 오버레이 - 클릭 닫기 제거 */
 .preview-modal-overlay {
   position: fixed;
   top: 0;
@@ -490,30 +350,66 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  backdrop-filter: blur(4px);
 }
 
 .preview-modal {
-  background: #f0f0f0;
+  background: #f8fafc;
   border-radius: 12px;
   width: 680px;
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+  animation: modalSlideUp 0.3s ease;
+}
+
+@keyframes modalSlideUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .preview-modal-header {
   padding: 20px 24px 16px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid #e2e8f0;
   background: #fff;
   border-radius: 12px 12px 0 0;
+}
+
+.modal-title-group h2 {
+  margin: 0 0 4px 0;
+  font-size: 1.125em;
+  font-weight: 700;
+  color: #111827;
+}
+
+.modal-subtitle {
+  font-size: 0.8125em;
+  color: #94a3b8;
+}
+
+.modal-close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #94a3b8;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  border-radius: 50%;
+  transition: all 0.2s;
+}
+
+.modal-close-btn:hover {
+  background-color: #f1f5f9;
+  color: #374151;
 }
 
 .preview-modal-body {
   flex: 1;
   overflow-y: auto;
   padding: 24px;
-  background: #f0f0f0;
+  background: #f8fafc;
 }
 
 /* 문서 페이지 느낌 */
@@ -526,11 +422,11 @@
   width: 100%;
   max-width: 580px;
   background: #ffffff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   border-radius: 2px;
   padding: 48px 56px;
   min-height: 400px;
-  overflow-x: auto;    
+  overflow-x: auto;
   box-sizing: border-box;
 }
 
@@ -555,54 +451,50 @@
 }
 
 .preview-modal-footer {
-  padding: 16px 24px;
-  border-top: 1px solid #e0e0e0;
+  padding: 14px 24px;
+  border-top: 1px solid #e2e8f0;
   display: flex;
   justify-content: flex-end;
-  gap: 12px;
+  gap: 10px;
   background: #fff;
   border-radius: 0 0 12px 12px;
 }
 
-/* ── 반응형 ── */
-@media (max-width: 768px) {
-  .apply-guide-btn {
-    bottom: 20px;
-    right: 20px;
-    padding: 12px 18px;
-    font-size: 0.8125em;
-  }
-
-  .preview-modal {
-    max-width: 95%;
-  }
-
-  .preview-modal-header {
-    padding: 16px;
-  }
-
-  .modal-title-group h2 {
-    font-size: 1.0625em;
-  }
-
-  .preview-content {
-    padding: 30px 24px;
-  }
-
-  .preview-modal-footer {
-    flex-direction: column;
-    padding: 14px 16px;
-  }
-
-  .modal-cancel-btn,
-  .modal-save-btn {
-    width: 100%;
-    justify-content: center;
-  }
+.modal-cancel-btn,
+.modal-save-btn {
+  padding: 9px 20px;
+  border-radius: 8px;
+  font-size: 0.875em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
+.modal-cancel-btn {
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  color: #64748b;
+}
 
+.modal-cancel-btn:hover {
+  background-color: #f8fafc;
+  border-color: #cbd5e1;
+}
 
+.modal-save-btn {
+  background-color: #4099FD;
+  border: none;
+  color: white;
+}
+
+.modal-save-btn:hover {
+  background-color: #2b87f0;
+}
+
+/* HTML 미리보기 */
 .preview-doc-html {
   font-family: '맑은 고딕', 'Noto Sans KR', sans-serif;
   font-size: 13px;
@@ -622,7 +514,7 @@
   border: 1px solid #ccc;
   padding: 6px 10px;
   vertical-align: top;
-   word-break: break-word; 
+  word-break: break-word;
   overflow-wrap: break-word;
 }
 
@@ -631,8 +523,8 @@
 }
 
 .preview-doc-html td,
-.preview-doc-html th{ 
-  border: 1px solid #ccc; 
+.preview-doc-html th {
+  border: 1px solid #ccc;
   padding: 6px 10px;
   vertical-align: top;
   font-size: 13px;
@@ -642,4 +534,55 @@
 .preview-doc-html img {
   max-width: 100%;
   height: auto;
+}
+
+/* ── 반응형 ── */
+@media (max-width: 768px) {
+  .apply-guide-btn {
+    bottom: 20px;
+    right: 72px;
+    padding: 10px 14px;
+    font-size: 0.8125em;
+  }
+
+  .preview-modal {
+    max-width: 95%;
+  }
+
+  .preview-modal-header {
+    padding: 16px;
+  }
+
+  .modal-title-group h2 {
+    font-size: 1.0625em;
+  }
+
+  .preview-modal-footer {
+    flex-direction: column;
+    padding: 14px 16px;
+  }
+
+  .modal-cancel-btn,
+  .modal-save-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (min-width: 1600px) {
+  .guide-tip-box-wrapper { width: 960px; }
+  .guide-tip-box { width: 960px; }
+   .apply-guide-btn {
+    transform: translateX(calc(50% + 480px + 20px));
+    
+  }
+}
+
+@media (min-width: 1800px) {
+  .guide-tip-box-wrapper { width: 1100px; }
+  .guide-tip-box { width: 1100px; }
+  .apply-guide-btn {
+    transform: translateX(calc(80% + 550px + 20px));
+    
+  }
 }

--- a/frontend/src/components/mypage/layout/MypageLayout.css
+++ b/frontend/src/components/mypage/layout/MypageLayout.css
@@ -24,3 +24,13 @@
     padding: 24px 16px;
   }
 }
+
+@media (min-width: 1600px) {
+  .mypage-container {
+    grid-template-columns: 320px 1fr;
+  }
+  .mypage-content {
+    padding: 40px 56px;
+    max-width: 100%;
+  }
+}

--- a/frontend/src/components/mypage/layout/Sidebar.css
+++ b/frontend/src/components/mypage/layout/Sidebar.css
@@ -191,3 +191,14 @@
     display: none;
   }
 }
+
+@media (min-width: 1600px) {
+  .profile-section { padding: 28px 24px; }
+  .profile-avatar { width: 62px; height: 62px; }
+  .profile-name { font-size: 18px; }
+  .profile-email { font-size: 14px; }
+  .btn-edit-profile { height: 42px; font-size: 15px; }
+  .nav-item { font-size: 16px; padding: 14px 20px; height: 48px; gap: 16px; }
+  .nav-icon { font-size: 22px; width: 26px; }
+  .btn-logout { font-size: 15px; padding: 14px 24px; }
+}

--- a/frontend/src/components/mypage/mycommunity/MyCommunity.css
+++ b/frontend/src/components/mypage/mycommunity/MyCommunity.css
@@ -297,3 +297,39 @@
   text-overflow: ellipsis;
   max-width: 300px;
 }
+@media (min-width: 1600px) {
+  .mycommunity-header h1 {
+    font-size: 26px;
+  }
+  .mycommunity-tab-btn {
+    font-size: 16px;
+    min-width: 140px;
+    padding: 10px 0;
+  }
+  .mycommunity-controls {
+    margin-bottom: 16px;
+  }
+  .mycommunity-count {
+    font-size: 15px;
+  }
+  .mycommunity-delete-btn {
+    height: 40px;
+    padding: 0 20px;
+    font-size: 15px;
+  }
+  .mycommunity-table th {
+    font-size: 15px;
+    padding: 10px 24px;
+  }
+  .mycommunity-table td {
+    font-size: 15px;
+    padding: 10px 24px;
+  }
+  .mycommunity-table input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+  }
+  .mycommunity-empty-cell {
+    font-size: 15px;
+  }
+}

--- a/frontend/src/components/mypage/mydocuments/DraftTableMUI.tsx
+++ b/frontend/src/components/mypage/mydocuments/DraftTableMUI.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
   Paper, Chip, IconButton, Box, Typography, Menu, MenuItem,
@@ -8,127 +8,107 @@ import MoreVertIcon from '@mui/icons-material/MoreVert';
 import DeleteIcon from '@mui/icons-material/Delete';
 import RemoveRedEyeIcon from '@mui/icons-material/RemoveRedEye';
 import AccessTimeFilledRoundedIcon from '@mui/icons-material/AccessTimeFilledRounded';
+import { IoIosExit } from 'react-icons/io';
 import { useNavigate } from 'react-router-dom';
-import { categoryInfo, mockDrafts } from '../../../mock/mockDocuments';
+import { categoryInfo } from '../../../mock/mockDocuments';
 import { mypageAPI } from '../../../api/mypage';
 import { DraftDocument } from '../../../types';
+import { useToast, ToastType } from '../../../hooks/useToast';
+import Toast from '../../common/Toast';
 
 interface DraftTableProps {
-  sortOrder: string;
-  categoryFilter: string;
-  searchQuery: string;
+  documents: DraftDocument[];
+  isLoading: boolean;
+  onRefresh: () => void | Promise<void>;
 }
 
-export default function DraftTableMUI({ sortOrder, categoryFilter, searchQuery }: DraftTableProps) {
-  const [drafts, setDrafts] = useState<DraftDocument[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      setIsLoading(true);
-      try {
-        const sort = sortOrder === 'recent' ? 'recent' : sortOrder === 'oldest' ? 'old' : 'name';
-        const data = await mypageAPI.getDrafts(sort, categoryFilter === 'all' ? '' : categoryFilter);
-        const mapped = data.list.map((item: any) => ({
-          id: item.documentId,
-          title: item.title,
-          category: 'real_estate',
-          progress: item.progress || 0,
-          statusText: item.statusText || '미분석',
-          lastEditedAt: item.uploadDate ?? item.updatedAt ?? '',
-        }));
-        const filtered = searchQuery
-          ? mapped.filter((d: DraftDocument) => d.title.toLowerCase().includes(searchQuery.toLowerCase()))
-          : mapped;
-        setDrafts(filtered);
-      } catch (err) {
-        console.error('미분석 목록 로딩 실패:', err);
-        setDrafts(mockDrafts);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    fetchData();
-  }, [sortOrder, categoryFilter, searchQuery]);
+export default function DraftTableMUI({ documents, isLoading, onRefresh }: DraftTableProps) {
+  const { toast, showToast, hideToast } = useToast();
 
   return (
-    <TableContainer
-      component={Paper}
-      sx={{
-        borderRadius: '12px',
-        boxShadow: 'none',
-        border: '1px solid #E5E7EB',
-        '& .MuiTableCell-root': {
-          height: '38px',
-          maxHeight: '38px',
-          minHeight: '38px',
-          padding: '0px 16px',
-          boxSizing: 'border-box',
-          fontSize: '13px',
-        },
-      }}
-    >
-      <Table>
-        <TableHead>
-          <TableRow sx={{ backgroundColor: '#F9FAFB' }}>
-            <TableCell width="15%" sx={{ fontWeight: 600, color: '#6B7280', fontSize: '13px', borderBottom: '1px solid #E5E7EB' }}>
-              계약 유형
-            </TableCell>
-            <TableCell width="40%" sx={{ fontWeight: 600, color: '#6B7280', fontSize: '13px', borderBottom: '1px solid #E5E7EB' }}>
-              계약서 제목
-            </TableCell>
-            <TableCell width="15%" sx={{ fontWeight: 600, color: '#6B7280', fontSize: '13px', borderBottom: '1px solid #E5E7EB' }}>
-              업로드일
-            </TableCell>
-            <TableCell width="25%" sx={{ fontWeight: 600, color: '#6B7280', fontSize: '13px', borderBottom: '1px solid #E5E7EB' }}>
-              분석 상태
-            </TableCell>
-            <TableCell width="5%" sx={{ borderBottom: '1px solid #E5E7EB' }} />
-          </TableRow>
-        </TableHead>
+    <>
+      <TableContainer
+        component={Paper}
+        sx={{
+          borderRadius: '12px',
+          boxShadow: 'none',
+          border: '1px solid #E5E7EB',
+          '& .MuiTableCell-root': {
+            height: { xs: '38px', xl: '46px' },
+            maxHeight: { xs: '38px', xl: '46px' },
+            minHeight: { xs: '38px', xl: '46px' },
+            padding: { xs: '0px 16px', xl: '0px 20px' },
+            boxSizing: 'border-box',
+            fontSize: { xs: '13px', xl: '15px' },
+          },
+        }}
+      >
+        <Table>
+          <TableHead>
+            <TableRow sx={{ backgroundColor: '#F9FAFB' }}>
+              <TableCell width="15%" sx={{ fontWeight: 600, color: '#6B7280', fontSize: { xs: '13px', xl: '15px' }, borderBottom: '1px solid #E5E7EB' }}>
+                계약 유형
+              </TableCell>
+              <TableCell width="40%" sx={{ fontWeight: 600, color: '#6B7280', fontSize: { xs: '13px', xl: '15px' }, borderBottom: '1px solid #E5E7EB' }}>
+                계약서 제목
+              </TableCell>
+              <TableCell width="15%" sx={{ fontWeight: 600, color: '#6B7280', fontSize: { xs: '13px', xl: '15px' }, borderBottom: '1px solid #E5E7EB' }}>
+                업로드일
+              </TableCell>
+              <TableCell width="25%" sx={{ fontWeight: 600, color: '#6B7280', fontSize: { xs: '13px', xl: '15px' }, borderBottom: '1px solid #E5E7EB' }}>
+                분석 상태
+              </TableCell>
+              <TableCell width="5%" sx={{ borderBottom: '1px solid #E5E7EB' }} />
+            </TableRow>
+          </TableHead>
 
-        <TableBody>
-          {isLoading ? (
-            <TableRow>
-              <TableCell colSpan={5} sx={{ textAlign: 'center', padding: '40px', color: '#6B7280' }}>
-                로딩 중...
-              </TableCell>
-            </TableRow>
-          ) : drafts.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={5} sx={{ padding: 0, border: 'none' }}>
-                <Box sx={{ padding: '60px 40px', textAlign: 'center', backgroundColor: '#fff' }}>
-                  <Typography sx={{ fontSize: '14px', color: '#6B7280' }}>
-                    미분석 계약서가 없습니다
-                  </Typography>
-                </Box>
-              </TableCell>
-            </TableRow>
-          ) : (
-            drafts.map((draft) => (
-              <DraftRow key={draft.id} draft={draft} />
-            ))
-          )}
-        </TableBody>
-      </Table>
-    </TableContainer>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={5} sx={{ textAlign: 'center', padding: '40px', color: '#6B7280' }}>
+                  로딩 중...
+                </TableCell>
+              </TableRow>
+            ) : documents.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} sx={{ padding: 0, border: 'none' }}>
+                  <Box sx={{ padding: '60px 40px', textAlign: 'center', backgroundColor: '#fff' }}>
+                    <Typography sx={{ fontSize: '14px', color: '#6B7280' }}>
+                      미분석 계약서가 없습니다
+                    </Typography>
+                  </Box>
+                </TableCell>
+              </TableRow>
+            ) : (
+              documents.map((draft) => (
+                <DraftRow key={draft.id} draft={draft} onRefresh={onRefresh} onToast={showToast} />
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Toast {...toast} onClose={hideToast} />
+    </>
   );
 }
 
-function DraftRow({ draft }: { draft: DraftDocument }) {
+function DraftRow({
+  draft,
+  onRefresh,
+  onToast,
+}: {
+  draft: DraftDocument;
+  onRefresh: () => void;
+  onToast: (message: string, type: ToastType) => void;
+}) {
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const open = Boolean(anchorEl);
 
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
 
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  // ✅ 보기 — 분석 페이지로 이동
   const handleView = () => {
     handleClose();
     navigate('/analysis', {
@@ -136,123 +116,92 @@ function DraftRow({ draft }: { draft: DraftDocument }) {
     });
   };
 
-  const handleDelete = () => {
-    console.log('삭제:', draft.id);
-    handleClose();
+  const handleDeleteConfirm = async () => {
+    setShowDeleteModal(false);
+    try {
+      await mypageAPI.deleteDocument(draft.id);
+      onRefresh();
+      onToast('계약서가 삭제되었습니다.', 'success');
+    } catch (e) {
+      onToast('삭제에 실패했습니다.', 'error');
+    }
   };
 
   return (
-    <TableRow
-      sx={{
-        '&:hover': { backgroundColor: '#FAFBFC' },
-        borderBottom: '1px solid #F3F4F6',
-      }}
-    >
-      {/* 계약유형 */}
-      <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
-        <Chip
-          label={categoryInfo[draft.category]?.label ?? '부동산'}
-          sx={{
-            backgroundColor: '#dbeafe',
-            color: '#1d4ed8',
-            fontWeight: 600,
-            fontSize: '11px',
-            width: '55px',
-            height: '24px',
-            borderRadius: '6px',
-          }}
-        />
-      </TableCell>
+    <>
+      <TableRow sx={{ '&:hover': { backgroundColor: '#FAFBFC' }, borderBottom: '1px solid #F3F4F6' }}>
+        <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
+          <Chip
+            label={categoryInfo[draft.category]?.label ?? '부동산'}
+            sx={{ backgroundColor: '#dbeafe', color: '#1d4ed8', fontWeight: 600, fontSize: '11px', width: '55px', height: '24px', borderRadius: '6px' }}
+          />
+        </TableCell>
 
-      {/* 계약서 제목 */}
-      <TableCell sx={{ borderBottom: '1px solid #F3F4F6', maxWidth: 0 }}>
-        <Typography
-          sx={{
-            fontSize: '14px',
-            fontWeight: 500,
-            color: '#111827',
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {draft.title}
-        </Typography>
-      </TableCell>
-
-      {/* 업로드일 */}
-      <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
-        <Typography sx={{ fontSize: '14px', color: '#6B7280' }}>
-          {formatDateString(draft.lastEditedAt)}
-        </Typography>
-      </TableCell>
-
-      {/* ✅ 분석 상태 */}
-      <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <AccessTimeFilledRoundedIcon sx={{ fontSize: '18px', color: '#F59E0B' }} />
-          <Typography sx={{ fontSize: '14px', fontWeight: 500, color: '#F59E0B' }}>
-            {draft.statusText || '미분석'}
+        <TableCell sx={{ borderBottom: '1px solid #F3F4F6', maxWidth: 0 }}>
+          <Typography sx={{ fontSize: { xs: '14px', xl: '15px' }, fontWeight: 500, color: '#111827', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+            {draft.title}
           </Typography>
-        </Box>
-      </TableCell>
+        </TableCell>
 
-      {/* 더보기 */}
-      <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
-        <IconButton
-          size="small"
-          onClick={handleClick}
-          sx={{
-            color: '#9CA3AF',
-            padding: '6px',
-            '&:hover': { backgroundColor: '#F3F4F6', color: '#6B7280', borderRadius: '5px' },
-          }}
-        >
-          <MoreVertIcon sx={{ fontSize: '18px' }} />
-        </IconButton>
+        <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
+          <Typography sx={{ fontSize: { xs: '14px', xl: '15px' }, color: '#6B7280' }}>
+            {formatDateString(draft.lastEditedAt)}
+          </Typography>
+        </TableCell>
 
-        <Menu
-          anchorEl={anchorEl}
-          open={open}
-          onClose={handleClose}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-          PaperProps={{
-            sx: {
-              borderRadius: '12px',
-              boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
-              border: '1px solid #E5E7EB',
-              minWidth: '180px',
-              mt: 0.5,
-            },
-          }}
-        >
-          {/* ✅ 보기 — 분석 페이지로 이동 */}
-          <MenuItem onClick={handleView} sx={{ padding: '12px 16px', '&:hover': { backgroundColor: '#F9FAFB' } }}>
-            <ListItemIcon>
-              <RemoveRedEyeIcon sx={{ fontSize: '20px', color: '#374151' }} />
-            </ListItemIcon>
-            <ListItemText
-              primary="보기"
-              primaryTypographyProps={{ fontSize: '14px', fontWeight: 500, color: '#374151' }}
-            />
-          </MenuItem>
+        <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <AccessTimeFilledRoundedIcon sx={{ fontSize: { xs: '18px', xl: '20px' }, color: '#F59E0B' }} />
+            <Typography sx={{ fontSize: { xs: '14px', xl: '15px' }, fontWeight: 500, color: '#F59E0B' }}>
+              {draft.statusText || '미분석'}
+            </Typography>
+          </Box>
+        </TableCell>
 
-          <Divider sx={{ my: 0.5 }} />
+        <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
+          <IconButton size="small" onClick={handleClick} sx={{ color: '#9CA3AF', padding: '6px', '&:hover': { backgroundColor: '#F3F4F6', color: '#6B7280', borderRadius: '5px' } }}>
+            <MoreVertIcon sx={{ fontSize: '18px' }} />
+          </IconButton>
+          <Menu
+            anchorEl={anchorEl} open={open} onClose={handleClose}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            PaperProps={{ sx: { borderRadius: '12px', boxShadow: '0 4px 12px rgba(0,0,0,0.1)', border: '1px solid #E5E7EB', minWidth: '180px', mt: 0.5 } }}
+          >
+            <MenuItem onClick={handleView} sx={{ padding: '12px 16px', '&:hover': { backgroundColor: '#F9FAFB' } }}>
+              <ListItemIcon><RemoveRedEyeIcon sx={{ fontSize: '20px', color: '#374151' }} /></ListItemIcon>
+              <ListItemText primary="보기" primaryTypographyProps={{ fontSize: '14px', fontWeight: 500, color: '#374151' }} />
+            </MenuItem>
+            <Divider sx={{ my: 0.5 }} />
+            <MenuItem onClick={() => { handleClose(); setShowDeleteModal(true); }} sx={{ padding: '12px 16px', '&:hover': { backgroundColor: '#FEF2F2' } }}>
+              <ListItemIcon><DeleteIcon sx={{ fontSize: '20px', color: '#DC2626' }} /></ListItemIcon>
+              <ListItemText primary="삭제" primaryTypographyProps={{ fontSize: '14px', fontWeight: 500, color: '#DC2626' }} />
+            </MenuItem>
+          </Menu>
+        </TableCell>
+      </TableRow>
 
-          {/* 삭제 */}
-          <MenuItem onClick={handleDelete} sx={{ padding: '12px 16px', '&:hover': { backgroundColor: '#FEF2F2' } }}>
-            <ListItemIcon>
-              <DeleteIcon sx={{ fontSize: '20px', color: '#DC2626' }} />
-            </ListItemIcon>
-            <ListItemText
-              primary="삭제"
-              primaryTypographyProps={{ fontSize: '14px', fontWeight: 500, color: '#DC2626' }}
-            />
-          </MenuItem>
-        </Menu>
-      </TableCell>
-    </TableRow>
+      {/* 삭제 확인 모달 */}
+      {showDeleteModal && (
+        <tr>
+          <td colSpan={5} style={{ padding: 0, border: 'none' }}>
+            <div className="exit-modal-overlay">
+              <div className="exit-modal">
+                <div className="modal-icon">
+                  <IoIosExit size={32} color="#E53E3E" />
+                </div>
+                <p className="exit-modal-text">계약서를 삭제하시겠습니까?</p>
+                <p className="exit-modal-sub">'{draft.title}' 계약서가 영구적으로 삭제됩니다.</p>
+                <div className="exit-modal-buttons">
+                  <button className="exit-cancel-btn" onClick={() => setShowDeleteModal(false)}>취소</button>
+                  <button className="exit-confirm-btn" onClick={handleDeleteConfirm}>삭제하기</button>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
   );
 }
 

--- a/frontend/src/components/mypage/mydocuments/MyDocument.css
+++ b/frontend/src/components/mypage/mydocuments/MyDocument.css
@@ -278,3 +278,25 @@
     min-width: calc(33.333% - 6px);
   }
 }
+
+@media (min-width: 1600px) {
+  .documents-header h1 {
+    font-size: 26px;
+  }
+  .tab-btn {
+    font-size: 16px;
+    padding: 12px 40px;
+    min-width: 140px;
+  }
+  .search-box input {
+    font-size: 15px;
+  }
+  .filter-select {
+    font-size: 15px;
+    padding: 12px 18px;
+  }
+  .btn-create {
+    font-size: 15px;
+    padding: 12px 28px;
+  }
+}

--- a/frontend/src/components/mypage/mydocuments/MyDocument.tsx
+++ b/frontend/src/components/mypage/mydocuments/MyDocument.tsx
@@ -1,14 +1,76 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import DraftTableMUI from './DraftTableMUI';
 import StorageTableMUI from './StorageTableMUI';
 import '../mydocuments/MyDocument.css';
 import { IoSearch } from "react-icons/io5";
+import { mypageAPI } from '../../../api/mypage';
+import { DraftDocument, StorageDocument } from '../../../types';
+import { mockStorageDocuments, mockDrafts } from '../../../mock/mockDocuments';
 
 export default function Documents() {
   const [activeTab, setActiveTab] = useState<'draft' | 'storage'>('draft');
   const [searchQuery, setSearchQuery] = useState('');
   const [categoryFilter, setCategoryFilter] = useState('all');
   const [sortOrder, setSortOrder] = useState('recent');
+  const [allDrafts, setAllDrafts] = useState<DraftDocument[]>([]);
+  const [allStorage, setAllStorage] = useState<StorageDocument[]>([]);
+  const [isDraftLoading, setIsDraftLoading] = useState(false);
+  const [isStorageLoading, setIsStorageLoading] = useState(false);
+
+  // fetchDrafts, fetchStorage를 useCallback으로 감싸기
+const fetchDrafts = useCallback(async () => {
+  setIsDraftLoading(true);
+  try {
+    const sort = sortOrder === 'recent' ? 'recent' : sortOrder === 'oldest' ? 'old' : 'name';
+    const data = await mypageAPI.getDrafts(sort, '');
+    setAllDrafts(data.list.map((item: any) => ({
+      id: item.documentId ?? item._id ?? item.id,
+      title: item.title,
+      category: item.contractType || 'real_estate',
+      progress: item.progress || 0,
+      statusText: item.statusText || '미분석',
+      lastEditedAt: item.uploadDate ?? item.updatedAt ?? '',
+    })));
+  } catch (err) {
+    console.error('미분석 로딩 실패:', err);
+    setAllDrafts(mockDrafts);
+  } finally {
+    setIsDraftLoading(false);
+  }
+}, [sortOrder]);
+
+const fetchStorage = useCallback(async () => {
+  setIsStorageLoading(true);
+  try {
+    const sort = sortOrder === 'recent' ? 'recent' : sortOrder === 'oldest' ? 'old' : 'name';
+    const data = await mypageAPI.getStorage(sort, '');
+    setAllStorage(data.list.map((item: any) => ({
+      id: item.documentId ?? item._id ?? item.id,
+      title: item.title,
+      category: item.contractType || 'real_estate',
+      uploadedAt: item.uploadDate ?? item.UploadDate ?? item.createdAt ?? '',
+      analysisStatus: item.analysisStatus === '분석 완료' ? 'completed' : 'pending',
+      fileUrl: item.fileUrl ?? '',
+    })));
+  } catch (err) {
+    console.error('보관함 로딩 실패:', err);
+    setAllStorage(mockStorageDocuments);
+  } finally {
+    setIsStorageLoading(false);
+  }
+}, [sortOrder]);
+
+useEffect(() => { fetchDrafts(); }, [fetchDrafts]);
+useEffect(() => { fetchStorage(); }, [fetchStorage]);
+
+  // 검색 + 카테고리 필터 모두 프론트에서 처리
+  const filteredDrafts = allDrafts
+    .filter(d => categoryFilter === 'all' || d.category === categoryFilter)
+    .filter(d => !searchQuery || d.title.toLowerCase().includes(searchQuery.toLowerCase()));
+
+  const filteredStorage = allStorage
+    .filter(d => categoryFilter === 'all' || d.category === categoryFilter)
+    .filter(d => !searchQuery || d.title.toLowerCase().includes(searchQuery.toLowerCase()));
 
   return (
     <div className="documents-page">
@@ -16,7 +78,6 @@ export default function Documents() {
         <h1>내 계약서</h1>
       </header>
 
-      {/* 슬라이딩 탭 */}
       <div className="sliding-tabs">
         <div className="tabs-wrapper">
           <button
@@ -38,7 +99,6 @@ export default function Documents() {
         </div>
       </div>
 
-      {/* 필터 & 검색 */}
       <div className="controls-area">
         <div className="search-box">
           <input
@@ -58,7 +118,7 @@ export default function Documents() {
             onChange={(e) => setCategoryFilter(e.target.value)}
           >
             <option value="all">계약유형</option>
-            <option value="real_estate">부동산</option>
+            <option value="부동산">부동산</option>
           </select>
           <select
             className="filter-select"
@@ -70,16 +130,12 @@ export default function Documents() {
             <option value="name">이름순</option>
           </select>
         </div>
-        <button className="btn-create">
-          +&nbsp; 계약서 작성하기
-        </button>
       </div>
 
-      {/* 탭 컨텐츠 */}
       <div className="tab-content">
         {activeTab === 'draft'
-          ? <DraftTableMUI sortOrder={sortOrder} categoryFilter={categoryFilter} searchQuery={searchQuery} />
-          : <StorageTableMUI sortOrder={sortOrder} categoryFilter={categoryFilter} searchQuery={searchQuery} />
+? <DraftTableMUI documents={filteredDrafts} isLoading={isDraftLoading} onRefresh={fetchDrafts} />
+: <StorageTableMUI documents={filteredStorage} isLoading={isStorageLoading} onRefresh={fetchStorage} />
         }
       </div>
     </div>

--- a/frontend/src/components/mypage/mydocuments/StorageTableMUI.tsx
+++ b/frontend/src/components/mypage/mydocuments/StorageTableMUI.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
   Paper, Chip, IconButton, Box, Typography, Menu, MenuItem,
@@ -10,284 +10,211 @@ import RemoveRedEyeIcon from '@mui/icons-material/RemoveRedEye';
 import DownloadIcon from '@mui/icons-material/Download';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import AccessTimeFilledRoundedIcon from '@mui/icons-material/AccessTimeFilledRounded';
+import { IoIosExit } from 'react-icons/io';
 import { useNavigate } from 'react-router-dom';
 import { StorageDocument } from '../../../types';
 import { mypageAPI } from '../../../api/mypage';
-import { mockStorageDocuments, categoryInfo } from '../../../mock/mockDocuments';
+import { categoryInfo } from '../../../mock/mockDocuments';
+import { useToast, ToastType } from '../../../hooks/useToast';
+import Toast from '../../common/Toast';
 
 interface StorageTableProps {
-  sortOrder: string;
-  categoryFilter: string;
-  searchQuery: string;
+  documents: StorageDocument[];
+  isLoading: boolean;
+  onRefresh: () => void | Promise<void>;
 }
 
-export default function StorageTableMUI({ sortOrder, categoryFilter, searchQuery }: StorageTableProps) {
-  const [documents, setDocuments] = useState<StorageDocument[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+export default function StorageTableMUI({ documents, isLoading, onRefresh }: StorageTableProps) {
+  const { toast, showToast, hideToast } = useToast();
 
-  const fetchData = async () => {
-    setIsLoading(true);
-    try {
-      const sort = sortOrder === 'recent' ? 'recent' : sortOrder === 'oldest' ? 'old' : 'name';
-      // 필터값 변환: 'all' → '', '부동산' → '부동산' 그대로 전달
-      const contractType = categoryFilter === 'all' ? '' : categoryFilter;
-      const data = await mypageAPI.getStorage(sort, contractType);
-      const mapped = data.list.map((item: any) => ({
-        id: item.documentId,
-        title: item.title,
-        category: 'real_estate',
-        // 백엔드 응답 필드명 uploadDate (소문자) 또는 UploadDate 양쪽 대응
-        uploadedAt: item.uploadDate ?? item.UploadDate ?? item.createdAt ?? '',
-        analysisStatus: item.analysisStatus === '분석 완료' ? 'completed' : 'pending',
-        fileUrl: item.fileUrl ?? '',
-      }));
-      const filtered = searchQuery
-        ? mapped.filter((doc: StorageDocument) => doc.title.toLowerCase().includes(searchQuery.toLowerCase()))
-        : mapped;
-      setDocuments(filtered);
-    } catch (err) {
-      console.error('보관함 로딩 실패:', err);
-      setDocuments(mockStorageDocuments);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchData();
-  }, [sortOrder, categoryFilter, searchQuery]);
-
-  const columnWidths = {
-    category: '15%',
-    title: '40%',
-    date: '15%',
-    status: '25%',
-    actions: '5%',
-  };
+  const columnWidths = { category: '15%', title: '40%', date: '15%', status: '25%', actions: '5%' };
 
   return (
-    <TableContainer
-      component={Paper}
-      sx={{
-        borderRadius: '12px',
-        boxShadow: 'none',
-        border: '1px solid #E5E7EB',
-        '& .MuiTableCell-root': {
-          height: '38px',
-          minHeight: '38px',
-          maxHeight: '38px',
-          padding: '0 16px',
-          boxSizing: 'border-box',
-        },
-      }}
-    >
-      <Table>
-        <TableHead>
-          <TableRow sx={{ backgroundColor: '#F9FAFB' }}>
-            <TableCell width={columnWidths.category} sx={{ fontWeight: 600, color: '#6B7280', fontSize: '13px', borderBottom: '1px solid #E5E7EB' }}>
-              계약 유형
-            </TableCell>
-            <TableCell width={columnWidths.title} sx={{ fontWeight: 600, color: '#6B7280', fontSize: '13px', borderBottom: '1px solid #E5E7EB' }}>
-              계약서 제목
-            </TableCell>
-            <TableCell width={columnWidths.date} sx={{ fontWeight: 600, color: '#6B7280', fontSize: '13px', borderBottom: '1px solid #E5E7EB' }}>
-              업로드일
-            </TableCell>
-            <TableCell width={columnWidths.status} sx={{ fontWeight: 600, color: '#6B7280', fontSize: '13px', borderBottom: '1px solid #E5E7EB' }}>
-              분석 상태
-            </TableCell>
-            <TableCell width={columnWidths.actions} sx={{ borderBottom: '1px solid #E5E7EB' }} />
-          </TableRow>
-        </TableHead>
+    <>
+      <TableContainer
+        component={Paper}
+        sx={{
+          borderRadius: '12px',
+          boxShadow: 'none',
+          border: '1px solid #E5E7EB',
+          '& .MuiTableCell-root': {
+            height: { xs: '38px', xl: '46px' },
+            maxHeight: { xs: '38px', xl: '46px' },
+            minHeight: { xs: '38px', xl: '46px' },
+            padding: { xs: '0 16px', xl: '0 20px' },
+            boxSizing: 'border-box',
+            fontSize: { xs: '13px', xl: '15px' },
+          },
+        }}
+      >
+        <Table>
+          <TableHead>
+            <TableRow sx={{ backgroundColor: '#F9FAFB' }}>
+              <TableCell width={columnWidths.category} sx={{ fontWeight: 600, color: '#6B7280', fontSize: { xs: '13px', xl: '15px' }, borderBottom: '1px solid #E5E7EB' }}>계약 유형</TableCell>
+              <TableCell width={columnWidths.title} sx={{ fontWeight: 600, color: '#6B7280', fontSize: { xs: '13px', xl: '15px' }, borderBottom: '1px solid #E5E7EB' }}>계약서 제목</TableCell>
+              <TableCell width={columnWidths.date} sx={{ fontWeight: 600, color: '#6B7280', fontSize: { xs: '13px', xl: '15px' }, borderBottom: '1px solid #E5E7EB' }}>업로드일</TableCell>
+              <TableCell width={columnWidths.status} sx={{ fontWeight: 600, color: '#6B7280', fontSize: { xs: '13px', xl: '15px' }, borderBottom: '1px solid #E5E7EB' }}>분석 상태</TableCell>
+              <TableCell width={columnWidths.actions} sx={{ borderBottom: '1px solid #E5E7EB' }} />
+            </TableRow>
+          </TableHead>
 
-        <TableBody>
-          {isLoading ? (
-            <TableRow>
-              <TableCell colSpan={5} sx={{ textAlign: 'center', padding: '40px', color: '#6B7280' }}>
-                로딩 중...
-              </TableCell>
-            </TableRow>
-          ) : documents.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={5} sx={{ padding: 0, border: 'none' }}>
-                <Box sx={{ padding: '60px 40px', textAlign: 'center', backgroundColor: '#fff' }}>
-                  <Typography sx={{ fontSize: '14px', color: '#6B7280' }}>
-                    보관 중인 계약서가 없습니다
-                  </Typography>
-                </Box>
-              </TableCell>
-            </TableRow>
-          ) : (
-            documents.map((doc) => (
-              <StorageRow key={doc.id} document={doc} onRefresh={fetchData} />
-            ))
-          )}
-        </TableBody>
-      </Table>
-    </TableContainer>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={5} sx={{ textAlign: 'center', padding: '40px', color: '#6B7280' }}>로딩 중...</TableCell>
+              </TableRow>
+            ) : documents.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} sx={{ padding: 0, border: 'none' }}>
+                  <Box sx={{ padding: '60px 40px', textAlign: 'center', backgroundColor: '#fff' }}>
+                    <Typography sx={{ fontSize: '14px', color: '#6B7280' }}>보관 중인 계약서가 없습니다</Typography>
+                  </Box>
+                </TableCell>
+              </TableRow>
+            ) : (
+              documents.map((doc) => (
+                <StorageRow key={doc.id} document={doc} onRefresh={onRefresh} onToast={showToast} />
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Toast {...toast} onClose={hideToast} />
+    </>
   );
 }
 
-// 각 행 컴포넌트
-function StorageRow({ document, onRefresh }: { document: StorageDocument; onRefresh: () => void }) {
+function StorageRow({
+  document,
+  onRefresh,
+  onToast,
+}: {
+  document: StorageDocument;
+  onRefresh: () => void;
+  onToast: (message: string, type: ToastType) => void;
+}) {
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const open = Boolean(anchorEl);
 
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
 
-  // 보기 — AiPage로 이동
   const handleView = () => {
     handleClose();
     navigate('/ai', { state: { documentId: document.id, filename: document.title, fromStorage: true } });
   };
 
-  // 다운로드 — fileUrl로 다운로드
   const handleDownload = () => {
     handleClose();
-    if (!document.fileUrl) {
-      alert('다운로드할 파일이 없습니다.');
-      return;
-    }
+    if (!document.fileUrl) { alert('다운로드할 파일이 없습니다.'); return; }
     const a = window.document.createElement('a');
     a.href = document.fileUrl;
     a.download = document.title;
     a.click();
   };
 
-  // 삭제
-  const handleDelete = async () => {
-    handleClose();
-    if (!window.confirm(`"${document.title}"을 삭제하시겠습니까?`)) return;
+  const handleDeleteConfirm = async () => {
+    setShowDeleteModal(false);
     try {
       await mypageAPI.deleteDocument(document.id);
       onRefresh();
+      onToast('계약서가 삭제되었습니다.', 'success');
     } catch (e) {
-      alert('삭제에 실패했습니다.');
+      onToast('삭제에 실패했습니다.', 'error');
     }
   };
 
   return (
-    <TableRow
-      sx={{
-        '&:hover': { backgroundColor: '#FAFBFC' },
-        borderBottom: '1px solid #F3F4F6',
-      }}
-    >
-      {/* 계약유형 */}
-      <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
-        <Chip
-          label={categoryInfo[document.category]?.label ?? '부동산'}
-          sx={{
-            backgroundColor: '#dbeafe',
-            color: '#1d4ed8',
-            fontWeight: 600,
-            fontSize: '11px',
-            width: '55px',
-            height: '24px',
-            borderRadius: '6px',
-          }}
-        />
-      </TableCell>
+    <>
+      <TableRow sx={{ '&:hover': { backgroundColor: '#FAFBFC' }, borderBottom: '1px solid #F3F4F6' }}>
+        <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
+          <Chip
+            label={categoryInfo[document.category]?.label ?? '부동산'}
+            sx={{ backgroundColor: '#dbeafe', color: '#1d4ed8', fontWeight: 600, fontSize: '11px', width: '55px', height: '24px', borderRadius: '6px' }}
+          />
+        </TableCell>
 
-      {/* 계약서 제목 — 1줄 ellipsis */}
-      <TableCell sx={{ borderBottom: '1px solid #F3F4F6', maxWidth: 0 }}>
-        <Typography
-          sx={{
-            fontSize: '14px',
-            fontWeight: 500,
-            color: '#111827',
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {document.title}
-        </Typography>
-      </TableCell>
+        <TableCell sx={{ borderBottom: '1px solid #F3F4F6', maxWidth: 0 }}>
+          <Typography sx={{ fontSize: { xs: '14px', xl: '15px' }, fontWeight: 500, color: '#111827', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+            {document.title}
+          </Typography>
+        </TableCell>
 
-      {/* 업로드일 */}
-      <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
-        <Typography sx={{ fontSize: '14px', color: '#6B7280' }}>
-          {formatDateString(document.uploadedAt)}
-        </Typography>
-      </TableCell>
+        <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
+          <Typography sx={{ fontSize: { xs: '14px', xl: '15px' }, color: '#6B7280' }}>
+            {formatDateString(document.uploadedAt)}
+          </Typography>
+        </TableCell>
 
-      {/* 분석상태 */}
-      <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          {document.analysisStatus === 'completed' ? (
-            <>
-              <CheckCircleIcon sx={{ fontSize: '18px', color: '#10B981' }} />
-              <Typography sx={{ fontSize: '14px', fontWeight: 500, color: '#10B981' }}>분석 완료</Typography>
-            </>
-          ) : (
-            <>
-              <AccessTimeFilledRoundedIcon sx={{ fontSize: '18px', color: '#F59E0B' }} />
-              <Typography sx={{ fontSize: '14px', fontWeight: 500, color: '#F59E0B' }}>미분석</Typography>
-            </>
-          )}
-        </Box>
-      </TableCell>
+        <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {document.analysisStatus === 'completed' ? (
+              <>
+                <CheckCircleIcon sx={{ fontSize: { xs: '18px', xl: '20px' }, color: '#10B981' }} />
+                <Typography sx={{ fontSize: { xs: '14px', xl: '15px' }, fontWeight: 500, color: '#10B981' }}>분석 완료</Typography>
+              </>
+            ) : (
+              <>
+                <AccessTimeFilledRoundedIcon sx={{ fontSize: { xs: '18px', xl: '20px' }, color: '#F59E0B' }} />
+                <Typography sx={{ fontSize: { xs: '14px', xl: '15px' }, fontWeight: 500, color: '#F59E0B' }}>미분석</Typography>
+              </>
+            )}
+          </Box>
+        </TableCell>
 
-      {/* 더보기 */}
-      <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
-        <IconButton
-          size="small"
-          onClick={handleClick}
-          sx={{
-            color: '#9CA3AF',
-            padding: '6px',
-            '&:hover': { backgroundColor: '#F3F4F6', color: '#6B7280' },
-          }}
-        >
-          <MoreVertIcon sx={{ fontSize: '18px' }} />
-        </IconButton>
+        <TableCell sx={{ borderBottom: '1px solid #F3F4F6' }}>
+          <IconButton size="small" onClick={handleClick} sx={{ color: '#9CA3AF', padding: '6px', '&:hover': { backgroundColor: '#F3F4F6', color: '#6B7280' } }}>
+            <MoreVertIcon sx={{ fontSize: '18px' }} />
+          </IconButton>
+          <Menu
+            anchorEl={anchorEl} open={open} onClose={handleClose}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            PaperProps={{ sx: { borderRadius: '12px', boxShadow: '0 4px 12px rgba(0,0,0,0.1)', border: '1px solid #E5E7EB', minWidth: '180px', mt: 0.5 } }}
+          >
+            <MenuItem onClick={handleView} sx={{ padding: '12px 16px', '&:hover': { backgroundColor: '#F9FAFB' } }}>
+              <ListItemIcon><RemoveRedEyeIcon sx={{ fontSize: '20px', color: '#374151' }} /></ListItemIcon>
+              <ListItemText primary="보기" primaryTypographyProps={{ fontSize: '14px', fontWeight: 500, color: '#374151' }} />
+            </MenuItem>
+            <MenuItem onClick={handleDownload} sx={{ padding: '12px 16px', '&:hover': { backgroundColor: '#F9FAFB' } }}>
+              <ListItemIcon><DownloadIcon sx={{ fontSize: '20px', color: '#374151' }} /></ListItemIcon>
+              <ListItemText primary="다운로드" primaryTypographyProps={{ fontSize: '14px', fontWeight: 500, color: '#374151' }} />
+            </MenuItem>
+            <Divider sx={{ my: 0.5 }} />
+            <MenuItem onClick={() => { handleClose(); setShowDeleteModal(true); }} sx={{ padding: '12px 16px', '&:hover': { backgroundColor: '#FEF2F2' } }}>
+              <ListItemIcon><DeleteIcon sx={{ fontSize: '20px', color: '#DC2626' }} /></ListItemIcon>
+              <ListItemText primary="삭제" primaryTypographyProps={{ fontSize: '14px', fontWeight: 500, color: '#DC2626' }} />
+            </MenuItem>
+          </Menu>
+        </TableCell>
+      </TableRow>
 
-        <Menu
-          anchorEl={anchorEl}
-          open={open}
-          onClose={handleClose}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-          PaperProps={{
-            sx: {
-              borderRadius: '12px',
-              boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
-              border: '1px solid #E5E7EB',
-              minWidth: '180px',
-              mt: 0.5,
-            },
-          }}
-        >
-          <MenuItem onClick={handleView} sx={{ padding: '12px 16px', '&:hover': { backgroundColor: '#F9FAFB' } }}>
-            <ListItemIcon><RemoveRedEyeIcon sx={{ fontSize: '20px', color: '#374151' }} /></ListItemIcon>
-            <ListItemText primary="보기" primaryTypographyProps={{ fontSize: '14px', fontWeight: 500, color: '#374151' }} />
-          </MenuItem>
-
-          <MenuItem onClick={handleDownload} sx={{ padding: '12px 16px', '&:hover': { backgroundColor: '#F9FAFB' } }}>
-            <ListItemIcon><DownloadIcon sx={{ fontSize: '20px', color: '#374151' }} /></ListItemIcon>
-            <ListItemText primary="다운로드" primaryTypographyProps={{ fontSize: '14px', fontWeight: 500, color: '#374151' }} />
-          </MenuItem>
-
-          <Divider sx={{ my: 0.5 }} />
-
-          <MenuItem onClick={handleDelete} sx={{ padding: '12px 16px', '&:hover': { backgroundColor: '#FEF2F2' } }}>
-            <ListItemIcon><DeleteIcon sx={{ fontSize: '20px', color: '#DC2626' }} /></ListItemIcon>
-            <ListItemText primary="삭제" primaryTypographyProps={{ fontSize: '14px', fontWeight: 500, color: '#DC2626' }} />
-          </MenuItem>
-        </Menu>
-      </TableCell>
-    </TableRow>
+      {/* 삭제 확인 모달 */}
+      {showDeleteModal && (
+        <tr>
+          <td colSpan={5} style={{ padding: 0, border: 'none' }}>
+            <div className="exit-modal-overlay">
+              <div className="exit-modal">
+                <div className="modal-icon">
+                  <IoIosExit size={32} color="#E53E3E" />
+                </div>
+                <p className="exit-modal-text">계약서를 삭제하시겠습니까?</p>
+                <p className="exit-modal-sub">'{document.title}' 계약서가 영구적으로 삭제됩니다.</p>
+                <div className="exit-modal-buttons">
+                  <button className="exit-cancel-btn" onClick={() => setShowDeleteModal(false)}>취소</button>
+                  <button className="exit-confirm-btn" onClick={handleDeleteConfirm}>삭제하기</button>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
   );
 }
 
-// 날짜 포맷 — 잘못된 날짜 방어 처리
 function formatDateString(dateString: string) {
   if (!dateString) return '-';
   const date = new Date(dateString);

--- a/frontend/src/components/mypage/myhome/MyHome.css
+++ b/frontend/src/components/mypage/myhome/MyHome.css
@@ -358,3 +358,26 @@
     min-height: 300px;
   }
 }
+
+@media (min-width: 1600px) {
+  .dashboard-header h1 { font-size: 28px; }
+  .my-section-title { font-size: 19px; margin-bottom: 16px; }
+  .activity-grid { border-radius: 14px; }
+  .activity-card { padding: 16px 32px; }
+  .card-icon { font-size: 24px; }
+  .card-title { font-size: 16px; }
+  .card-count { font-size: 18px; }
+  .analysis-grid { gap: 24px; margin-top: 48px; }
+  .analysis-card { padding: 36px; min-height: 520px; border-radius: 16px; }
+  .analysis-card-title { font-size: 17px; }
+  .analysis-card-sub { font-size: 12px; }
+  .donut-total { font-size: 34px; }
+  .donut-label { font-size: 13px; }
+  .risk-legend-name { font-size: 14px; }
+  .risk-legend-value { font-size: 14px; }
+  .upcoming-title { font-size: 15px; }
+  .upcoming-dday { font-size: 15px; min-width: 56px; }
+  .upcoming-date { font-size: 13px; }
+  .upcoming-item { padding: 14px 16px; border-radius: 10px; }
+  .risk-comment { font-size: 13px; }
+}

--- a/frontend/src/components/mypage/myhome/MyHome.tsx
+++ b/frontend/src/components/mypage/myhome/MyHome.tsx
@@ -220,7 +220,6 @@ export default function Dashboard() {
         <div className="analysis-grid">
 
           {/* 왼쪽 — 최근 계약서 위험도 분포 */}
-          {riskSummary.docTitle && (
           <div className="analysis-card gray">
             <div className="analysis-card-header">
               <div style={{ flex: 1, minWidth: 0 }}>
@@ -247,7 +246,7 @@ export default function Dashboard() {
               <div className="analysis-empty">
                 <p>분석된 계약서가 없습니다</p>
                 <span>계약서를 분석하고 보관함에 저장하면<br />위험 조항 현황을 확인할 수 있어요</span>
-                <button className="analysis-empty-btn" onClick={() => navigate('/ai')}>
+                <button className="analysis-empty-btn" onClick={() => navigate('/analysis')}>
                   계약서 분석하러 가기 →
                 </button>
               </div>
@@ -313,7 +312,6 @@ export default function Dashboard() {
               </div>
             )}
           </div>
-)}   
           {/* 오른쪽 — 다가오는 일정 */}
           <div className="analysis-card blue">
             <div className="analysis-card-header">

--- a/frontend/src/components/mypage/settings/Setting.css
+++ b/frontend/src/components/mypage/settings/Setting.css
@@ -576,3 +576,35 @@
 .settings-link-btn:hover {
   background: #dbeafe;
 }
+
+@media (min-width: 1600px) {
+  .settings-title {
+    font-size: 26px;
+  }
+  .settings-profile-card {
+    padding: 24px;
+  }
+  .settings-avatar {
+    width: 60px;
+    height: 60px;
+    font-size: 22px;
+  }
+  .settings-profile-name {
+    font-size: 17px;
+  }
+  .settings-profile-email {
+    font-size: 14px;
+  }
+  .settings-row {
+    padding: 12px 20px;
+  }
+  .settings-row-label {
+    font-size: 15px;
+  }
+  .settings-row-sub {
+    font-size: 13px;
+  }
+  .settings-section-title {
+    font-size: 13px;
+  }
+}

--- a/frontend/src/pages/AiPage.css
+++ b/frontend/src/pages/AiPage.css
@@ -144,3 +144,21 @@ align-items: center; justify-content: center;
     transform: translateY(0);
   }
 }
+@media (min-width: 1600px) {
+  .content-analysis-box {
+    width: 960px;
+  }
+
+  .content-analysis-box.has-header {
+    height: calc(100vh - 210px);
+  }
+}
+
+@media (min-width: 1800px) {
+  .content-analysis-box {
+    width: 1100px;
+  }
+   .main-content.sidebar-open {
+    margin-right: 450px; /
+  }
+}

--- a/frontend/src/pages/AiPage.tsx
+++ b/frontend/src/pages/AiPage.tsx
@@ -50,17 +50,17 @@ function AnalysisPage() {
   
 
 const maskPersonalInfo = (html: string): { masked: string; detected: boolean; counts: Record<string, number> } => {
-  const patterns = [
-    { regex: /\d{6}-\d{7}/g, replace: '******-*******', label: '주민번호' },
-    { regex: /01[0-9]-\d{3,4}-\d{4}/g, replace: '010-****-****', label: '전화번호' },
-    { regex: /\d{3,4}-\d{3,4}-\d{4,6}/g, replace: '****-****-****', label: '계좌번호' },
-    { regex: /\d{3}-\d{2}-\d{5}/g, replace: '***-**-*****', label: '사업자번호' },
-    { 
-      regex: /(서울|부산|대구|인천|광주|대전|울산|세종|경기도|강원도|충청북도|충청남도|전라북도|전라남도|경상북도|경상남도|제주도|충북|충남|전북|전남|경북|경남|제주)[^\s<]{2,80}(로|길|동|읍|면|리)(\s*\d+(-\d+)?(\s*\S+빌라|\s*\S+아파트|\s*\S+빌딩|\s*\d+호)?)?/g,
-      replace: '***',
-      label: '주소'
-    },
-  ];
+const patterns = [
+  { regex: /\d{6}-\d{7}/g, replace: '<span class="masked-text">******-*******</span>', label: '주민번호' },
+  { regex: /01[0-9]-\d{3,4}-\d{4}/g, replace: '<span class="masked-text">010-****-****</span>', label: '전화번호' },
+  { regex: /\d{3,4}-\d{3,4}-\d{4,6}/g, replace: '<span class="masked-text">****-****-****</span>', label: '계좌번호' },
+  { regex: /\d{3}-\d{2}-\d{5}/g, replace: '<span class="masked-text">***-**-*****</span>', label: '사업자번호' },
+  {
+    regex: /(서울|부산|대구|인천|광주|대전|울산|세종|경기도|강원도|충청북도|충청남도|전라북도|전라남도|경상북도|경상남도|제주도|충북|충남|전북|전남|경북|경남|제주)[^\s<]{2,80}(로|길|동|읍|면|리)(\s*\d+(-\d+)?(\s*\S+빌라|\s*\S+아파트|\s*\S+빌딩|\s*\d+호)?)?/g,
+    replace: '<span class="masked-text">***</span>',
+    label: '주소'
+  },
+];
   let result = html;
   let detected = false;
   const counts: Record<string, number> = {};

--- a/frontend/src/pages/CommunityPage.css
+++ b/frontend/src/pages/CommunityPage.css
@@ -1,13 +1,43 @@
 /* ===== 공통 ===== */
 .community-wrapper {
   min-height: calc(100vh - 60px);
-  padding: 30px 20px;
+  padding: 40px 20px;
   background-color: #fff;
 }
 
 .community-container {
   max-width: 1024px;
   margin: 0 auto;
+}
+
+/* ===== 배너 ===== */
+.page-banner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0px 0px 28px 0px;
+  margin-bottom: 28px;
+  border-bottom: 1px solid #F1F5F9;
+}
+
+.page-banner-icon {
+  font-size: 32px;
+  flex-shrink: 0;
+}
+
+.page-banner-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: #111827;
+  margin: 0 0 6px;
+  letter-spacing: -0.3px;
+}
+
+.page-banner-sub {
+  font-size: 13px;
+  color: #6B7280;
+  margin: 0;
+  line-height: 1.6;
 }
 
 /* ===== 헤더 ===== */
@@ -19,9 +49,9 @@
 }
 
 .community-title {
-  font-size: 22px;
-  font-weight: 700;
-  color: #1a1a2e;
+  font-size: 16px;
+  font-weight: 600;
+  color: #374151;
 }
 
 .write-btn {
@@ -29,8 +59,8 @@
   color: #fff;
   border: none;
   border-radius: 8px;
-  padding: 10px 32px;
-  font-size: 14px;
+  padding: 9px 24px;
+  font-size: 13px;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.2s;
@@ -39,7 +69,6 @@
 .write-btn:hover {
   background-color: #3B82F6;
 }
-
 
 /* ===== 뱃지 ===== */
 .badge {
@@ -51,8 +80,9 @@
 }
 
 .badge-best {
-  background-color: #ef4444;
-  color: #fff;
+  background-color: #FEF2F2;
+  color: #EF4444;
+  border: 1px solid #FECACA;
 }
 
 .badge-type {
@@ -60,22 +90,27 @@
   color: #475569;
 }
 
-.cat-blue { background-color: #dbeafe; color: #1d4ed8; }
-.cat-green { background-color: #dcfce7; color: #15803d; }
-.cat-orange { background-color: #ffedd5; color: #c2410c; }
-.cat-gray { background-color: #f1f5f9; color: #475569; }
+.cat-blue { background-color: #EFF6FF; color: #2563EB; border: 1px solid #BFDBFE; }
+.cat-green { background-color: #F0FDF4; color: #15803d; border: 1px solid #BBF7D0; }
+.cat-orange { background-color: #FFF7ED; color: #c2410c; border: 1px solid #FED7AA; }
+.cat-gray { background-color: #F8FAFC; color: #475569; border: 1px solid #E2E8F0; }
 
 /* ===== 베스트 게시글 ===== */
 .best-post-card {
-  background: #fff;
-  border: 1px solid #e5f0fc;
-  border-radius: 12px;
-  padding: 20px 24px;
-  margin-bottom: 24px;
+  background: #FAFBFF;
+  border: 1px solid #E5E7EB;
+  border-radius: 10px;
+  padding: 18px 20px;
+  margin-bottom: 18px;
   cursor: pointer;
-  transition: box-shadow 0.2s;
+  transition: box-shadow 0.2s, border-color 0.2s;
 }
 
+.best-post-card:hover {
+  box-shadow: 0 2px 12px rgba(64, 153, 253, 0.1);
+  border-color: #93C5FD;
+  border-left-color: #4099FD;
+}
 
 .best-post-badges {
   display: flex;
@@ -88,17 +123,18 @@
 }
 
 .best-post-title {
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 700;
-  color: #1e293b;
-  margin-bottom: 8px;
+  color: #1E293B;
+  margin-bottom: 6px;
 }
 
 .best-post-body {
-  font-size: 13px;
-  color: #64748b;
+  font-size: 12px;
+  color: #64748B;
   line-height: 1.6;
   display: -webkit-box;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
@@ -107,13 +143,13 @@
   display: flex;
   gap: 8px;
   font-size: 12px;
-  color: #94a3b8;
+  color: #94A3B8;
   align-items: center;
 }
 
 .meta-likes {
   margin-left: auto;
-  color: #ef4444;
+  color: #EF4444;
   font-weight: 600;
 }
 
@@ -121,7 +157,7 @@
 .search-filter-row {
   display: flex;
   gap: 10px;
-  margin-bottom: 8px;
+  margin-bottom: 18px;
   align-items: center;
 }
 
@@ -130,20 +166,52 @@
   position: relative;
 }
 
+.search-box input {
+  width: 100%;
+  padding: 9px 36px 9px 14px;
+  border: 1px solid #E5E7EB;
+  border-radius: 8px;
+  font-size: 13px;
+  outline: none;
+  transition: border 0.2s;
+  box-sizing: border-box;
+  color: #374151;
+}
 
+.search-box input:focus {
+  border-color: #4099FD;
+}
 
 .search-icon {
   position: absolute;
   right: 12px;
   top: 50%;
-  transform: translateY(-40%);
-  font-size: 14px;
+  transform: translateY(-50%);
+  font-size: 15px;
+  color: #9CA3AF;
+}
+
+.filter-select {
+  padding: 9px 12px;
+  border: 1px solid #E5E7EB;
+  border-radius: 8px;
+  font-size: 13px;
+  color: #374151;
+  background: #fff;
+  outline: none;
+  cursor: pointer;
+  transition: border 0.2s;
+}
+
+.filter-select:focus {
+  border-color: #4099FD;
 }
 
 /* ===== 게시글 목록 ===== */
 .post-list {
   background: #fff;
-  border-radius: 12px;
+  border: 1px solid #E5E7EB;
+  border-radius: 10px;
   overflow: hidden;
   margin-bottom: 24px;
 }
@@ -152,9 +220,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 18px 0px;
-  border-bottom: 1px solid #f1f5f9;
+  padding: 18px 20px;
+  border-bottom: 1px solid #F1F5F9;
+  transition: background 0.15s;
+}
 
+.post-item:hover {
+  background: #FAFBFF;
 }
 
 .post-item:last-child {
@@ -164,24 +236,26 @@
 .post-item-left {
   flex: 1;
   min-width: 0;
+
 }
 
 .post-badges {
   display: flex;
   gap: 6px;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
 .post-item-title {
   font-size: 14px;
   font-weight: 600;
-  color: #1e293b;
-  margin-bottom: 12px;
+  color: #1E293B;
+  margin-bottom: 6px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   cursor: pointer;
 }
+
 .post-item-title:hover {
   text-decoration: underline;
   color: #4099FD;
@@ -189,22 +263,24 @@
 
 .post-item-body {
   font-size: 12px;
-  color: #6B6B6B;
+  color: #6B7280;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
   cursor: pointer;
 }
+
 .post-item-body:hover {
   text-decoration: underline;
 }
+
 .post-item-meta {
   display: flex;
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  color: #94a3b8;
+  color: #94A3B8;
 }
 
 .post-likes-spacer {
@@ -213,15 +289,15 @@
 
 .post-likes {
   font-size: 12px;
-  color: #ef4444;
+  color: #EF4444;
   font-weight: 600;
-  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .empty-state {
   padding: 60px;
   text-align: center;
-  color: #94a3b8;
+  color: #94A3B8;
   font-size: 14px;
 }
 
@@ -234,13 +310,13 @@
 }
 
 .page-btn {
-  width: 36px;
-  height: 36px;
-  border: 1px solid #e2e8f0;
+  width: 34px;
+  height: 34px;
+  border: 1px solid #E5E7EB;
   background: #fff;
   border-radius: 8px;
   font-size: 13px;
-  color: #475569;
+  color: #6B7280;
   cursor: pointer;
   font-family: 'KoPub', sans-serif;
   transition: all 0.2s;
@@ -262,11 +338,11 @@
 }
 
 .page-arrow {
-  font-size: 16px;
+  font-size: 14px;
 }
 
 .page-dots {
-  color: #94a3b8;
+  color: #94A3B8;
   font-size: 14px;
   padding: 0 4px;
 }
@@ -275,7 +351,7 @@
 .post-detail-wrapper {
   background-color: #fff;
   min-height: calc(100vh - 60px);
-  padding: 30px 20px;
+  padding: 40px 20px;
 }
 
 .post-detail-container {
@@ -283,27 +359,36 @@
   margin: 0 auto;
 }
 
-
 .back-btn {
-  background: none;
-  border: none;
-  color: #858D99;
-  font-size: 14px;
-  cursor: pointer;
-  font-family: 'KoPub', sans-serif;
   display: flex;
   align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid #E5E7EB;
+  border-radius: 8px;
+  color: #6B7280;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 7px 14px;
+  margin-bottom: 20px;
+  transition: all 0.2s;
+  font-family: 'KoPub', sans-serif;
 }
+.back-btn:hover {
+  border-color: #4099FD;
+  color: #4099FD;
+  background: #EFF6FF;
+}
+.back-btn-icon { width: 20px; display: flex; margin-right: 4px; }
 
-.back-btn:hover { color: #3b82f6; }
-.back-btn-icon {width: 20px;display: flex; margin-right: 4px;}
 .post-detail-card {
   background: #fff;
   border-radius: 12px;
   padding: 24px 0px;
   margin-bottom: 24px;
   min-height: 400px;
-   display: flex;
+  display: flex;
   flex-direction: column;
 }
 
@@ -316,7 +401,7 @@
 .post-detail-title {
   font-size: 20px;
   font-weight: 700;
-  color: #1e293b;
+  color: #1E293B;
   margin-bottom: 12px;
   line-height: 1.4;
 }
@@ -325,10 +410,10 @@
   display: flex;
   gap: 10px;
   font-size: 13px;
-  color: #94a3b8;
+  color: #94A3B8;
   margin-bottom: 24px;
   padding-bottom: 20px;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid #F1F5F9;
 }
 
 .post-detail-body {
@@ -340,7 +425,7 @@
 
 .post-detail-actions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 12px;
   margin-top: auto;
 }
@@ -348,21 +433,27 @@
 .like-btn {
   display: flex;
   align-items: center;
-  padding: 8px 20px;
-  border-radius: 8px;
-  font-size: 14px;
+  gap: 4px;
+  border-radius: 20px;
+  font-size: 12px;
   font-family: 'KoPub', sans-serif;
   cursor: pointer;
-  border: 1px solid #e2e8f0;
+  border: none;
   background: #fff;
-  color: #64748b;
+  color: #94A3B8;
   transition: all 0.2s;
-  width: 100px;
-justify-content: center;
 }
-
-.like-btn:hover { border-color: #3b82f6; color: #3b82f6; }
-.like-btn.liked { background: #fef2f2; border-color: #ef4444; color: #ef4444; }
+.like-btn:hover {
+  color: #EF4444;
+}
+.like-btn.liked {
+  background: #FEF2F2;
+  border-color: #EF4444;
+  color: #EF4444;
+}
+.like-count {
+  font-weight: 700;
+}
 
 /* ===== 댓글 ===== */
 .comments-section {
@@ -370,10 +461,11 @@ justify-content: center;
   border-radius: 12px;
 }
 
+
 .comments-title {
   font-size: 16px;
   font-weight: 700;
-  color: #1e293b;
+  color: #1E293B;
   margin-bottom: 20px;
 }
 
@@ -386,7 +478,7 @@ justify-content: center;
 .comment-input {
   flex: 1;
   padding: 12px 16px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid #E5E7EB;
   border-radius: 8px;
   font-size: 14px;
   font-family: 'KoPub', sans-serif;
@@ -396,7 +488,7 @@ justify-content: center;
   transition: border 0.2s;
 }
 
-.comment-input:focus { border-color: #3b82f6; }
+.comment-input:focus { border-color: #4099FD; }
 
 .comment-submit-btn {
   padding: 0 38px;
@@ -412,11 +504,11 @@ justify-content: center;
   transition: background 0.2s;
 }
 
-.comment-submit-btn:hover { background: #2563eb; }
+.comment-submit-btn:hover { background: #2563EB; }
 
 .comment-item {
   padding: 16px 0;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid #F1F5F9;
 }
 
 .comment-item:last-child { border-bottom: none; }
@@ -435,7 +527,7 @@ justify-content: center;
 
 .comment-date {
   font-size: 12px;
-  color: #94a3b8;
+  color: #94A3B8;
 }
 
 .comment-body {
@@ -446,7 +538,7 @@ justify-content: center;
 
 .no-comments {
   text-align: center;
-  color: #94a3b8;
+  color: #94A3B8;
   font-size: 14px;
   padding: 32px 0;
 }
@@ -455,7 +547,7 @@ justify-content: center;
   display: flex;
   gap: 8px;
   margin-top: 10px;
-  display: flex; justify-content: flex-end;
+  justify-content: flex-end;
 }
 
 .comment-action-btn {
@@ -465,34 +557,21 @@ justify-content: center;
   padding: 4px 10px;
   border-radius: 6px;
   font-size: 12px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid #E5E7EB;
   background: #fff;
   cursor: pointer;
-  color: #94a3b8;
+  color: #94A3B8;
   transition: all 0.15s;
 }
 
-.comment-action-btn:hover {
-  border-color: #3b82f6;
-  color: #3b82f6;
-}
-
-.comment-action-btn.liked {
-  background: #fef2f2;
-  border-color: #ef4444;
-  color: #ef4444;
-}
-
-.comment-action-btn.disliked {
-  background: #eff6ff;
-  border-color: #3b82f6;
-  color: #3b82f6;
-}
+.comment-action-btn:hover { border-color: #4099FD; color: #4099FD; }
+.comment-action-btn.liked { background: #FEF2F2; border-color: #EF4444; color: #EF4444; }
+.comment-action-btn.disliked { background: #EFF6FF; border-color: #4099FD; color: #4099FD; }
 
 /* ===== 글쓰기 ===== */
 .write-wrapper {
-    min-height: 100vh;
-  background-color: #ffff;
+  min-height: 100vh;
+  background-color: #fff;
 }
 
 .write-container {
@@ -505,7 +584,7 @@ justify-content: center;
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid #E5E7EB;
   background: #fff;
   position: sticky;
   top: 0;
@@ -520,8 +599,8 @@ justify-content: center;
   color: #434242;
   font-weight: 800;
   padding: 8px 12px;
-    display: flex;
-    gap: 5px;
+  display: flex;
+  gap: 5px;
 }
 
 .write-submit-btn-header {
@@ -535,7 +614,7 @@ justify-content: center;
 }
 
 .write-submit-btn-header:disabled {
-  background: #93c5fd;
+  background: #93C5FD;
   cursor: not-allowed;
 }
 
@@ -551,9 +630,7 @@ justify-content: center;
   padding: 32px 32px 0px 32px;
 }
 
-.write-field {
-  margin-bottom: 20px;
-}
+.write-field { margin-bottom: 20px; }
 
 .write-label {
   display: block;
@@ -566,7 +643,7 @@ justify-content: center;
 .write-select {
   width: 100%;
   padding: 0px 16px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid #E5E7EB;
   border-radius: 8px;
   font-size: 14px;
   font-family: 'KoPub', sans-serif;
@@ -578,13 +655,12 @@ justify-content: center;
   height: 38px;
 }
 
-.write-select:focus { border-color: #3b82f6; }
-
+.write-select:focus { border-color: #4099FD; }
 
 .write-input {
   width: 100%;
   padding: 0px 16px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid #E5E7EB;
   border-radius: 8px;
   font-size: 14px;
   font-family: 'KoPub', sans-serif;
@@ -595,12 +671,12 @@ justify-content: center;
   height: 38px;
 }
 
-.write-input:focus { border-color: #3b82f6; }
+.write-input:focus { border-color: #4099FD; }
 
 .write-textarea {
   width: 100%;
   padding: 14px 16px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid #E5E7EB;
   border-radius: 8px;
   font-size: 14px;
   font-family: 'KoPub', sans-serif;
@@ -613,7 +689,7 @@ justify-content: center;
   box-sizing: border-box;
 }
 
-.write-textarea:focus { border-color: #3b82f6; }
+.write-textarea:focus { border-color: #4099FD; }
 
 .write-actions {
   display: flex;
@@ -621,24 +697,23 @@ justify-content: center;
   gap: 10px;
   margin-top: 24px;
 }
+
 .write-label-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-
 }
 
 .write-char-count {
   font-size: 12px;
-  color: #9ca3af;
+  color: #9CA3AF;
 }
 
-/* 커뮤니티 안내사항 */
 .write-guide {
   margin: 16px 32px 0px 32px;
   padding: 20px 24px;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
+  background: #F8FAFC;
+  border: 1px solid #E2E8F0;
   border-radius: 10px;
 }
 
@@ -656,7 +731,7 @@ justify-content: center;
 
 .write-guide-list li {
   font-size: 12px;
-  color: #64748b;
+  color: #64748B;
   line-height: 2;
 }
 
@@ -665,7 +740,7 @@ justify-content: center;
   align-items: center;
   gap: 8px;
   padding-top: 14px;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid #E2E8F0;
   cursor: pointer;
   font-size: 13px;
   font-weight: 600;
@@ -675,6 +750,42 @@ justify-content: center;
 .write-guide-check input[type="checkbox"] {
   width: 16px;
   height: 16px;
-  accent-color: #fff;
+  accent-color: #4099FD;
   cursor: pointer;
+}
+
+@media (min-width: 1600px) {
+  .community-wrapper {
+    padding: 48px 40px;
+  }
+  .community-container {
+    max-width: 1300px;
+  }
+  .post-detail-container {
+    max-width: 1300px;
+  }
+  .write-container {
+    max-width: 1300px;
+  }
+  .page-banner-title {
+    font-size: 26px;
+  }
+  .page-banner-sub {
+    font-size: 14px;
+  }
+  .post-item-title {
+    font-size: 15px;
+  }
+  .post-item-body {
+    font-size: 13px;
+  }
+  .best-post-title {
+    font-size: 15px;
+  }
+  .post-detail-title {
+    font-size: 22px;
+  }
+  .post-detail-body {
+    font-size: 16px;
+  }
 }

--- a/frontend/src/pages/CommunityPage.tsx
+++ b/frontend/src/pages/CommunityPage.tsx
@@ -31,79 +31,87 @@ export default function CommunityPage() {
   const [sortBy, setSortBy] = useState('최신순');
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
-  const TOTAL_PAGES = 10;
   const POSTS_PER_PAGE = 10;
 
-useEffect(() => {
-  const fetchPosts = async () => {
-    setIsLoading(true);
-    try {
-      const sortParam = sortBy === '조회순' ? 'views' : sortBy === '댓글순' ? 'comments' : 'latest';
-      const data = await communityAPI.getPosts(sortParam, selectedCategory, searchQuery);
-      setPosts(data);
-    } catch (err) {
-      console.error('게시글 로딩 실패:', err);
-      setPosts([]);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-  fetchPosts();
-  setCurrentPage(1);
-}, [sortBy, selectedCategory, searchQuery]);
+  useEffect(() => {
+    const fetchPosts = async () => {
+      setIsLoading(true);
+      try {
+        const sortParam = sortBy === '조회순' ? 'views' : sortBy === '댓글순' ? 'comments' : 'latest';
+        const data = await communityAPI.getPosts(sortParam, selectedCategory, searchQuery);
+        setPosts(data);
+      } catch (err) {
+        console.error('게시글 로딩 실패:', err);
+        setPosts([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchPosts();
+    setCurrentPage(1);
+  }, [sortBy, selectedCategory, searchQuery]);
 
-useEffect(() => {
-  const fetchBest = async () => {
-    try {
-      const data = await communityAPI.getBestPost();
-      setBestPost(data);
-    } catch (err) {
-      setBestPost(null);
-    }
-  };
-  fetchBest();
-}, []);
+  useEffect(() => {
+    const fetchBest = async () => {
+      try {
+        const data = await communityAPI.getBestPost();
+        setBestPost(data);
+      } catch (err) {
+        setBestPost(null);
+      }
+    };
+    fetchBest();
+  }, []);
 
-const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE);
-const pagedPosts = posts.slice(
-  (currentPage - 1) * POSTS_PER_PAGE,
-  currentPage * POSTS_PER_PAGE
-);
+  const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE);
+  const pagedPosts = posts.slice(
+    (currentPage - 1) * POSTS_PER_PAGE,
+    currentPage * POSTS_PER_PAGE
+  );
 
   const categoryColor: Record<string, string> = {
     '부동산': 'cat-blue',
   };
 
   const renderPagination = () => {
-  const pages = [];
-  pages.push(
-    <button key="first" className="page-btn page-arrow" onClick={() => setCurrentPage(1)}>«</button>,
-    <button key="prev" className="page-btn page-arrow" onClick={() => setCurrentPage(p => Math.max(1, p - 1))}>‹</button>
-  );
-  for (let i = 1; i <= totalPages; i++) {
+    const pages = [];
     pages.push(
-      <button
-        key={i}
-        className={`page-btn ${currentPage === i ? 'active' : ''}`}
-        onClick={() => setCurrentPage(i)}
-      >
-        {i}
-      </button>
+      <button key="first" className="page-btn page-arrow" onClick={() => setCurrentPage(1)}>«</button>,
+      <button key="prev" className="page-btn page-arrow" onClick={() => setCurrentPage(p => Math.max(1, p - 1))}>‹</button>
     );
-  }
-  pages.push(
-    <button key="next" className="page-btn page-arrow" onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}>›</button>,
-    <button key="last" className="page-btn page-arrow" onClick={() => setCurrentPage(totalPages)}>»</button>
-  );
-  return pages;
-};
+    for (let i = 1; i <= totalPages; i++) {
+      pages.push(
+        <button
+          key={i}
+          className={`page-btn ${currentPage === i ? 'active' : ''}`}
+          onClick={() => setCurrentPage(i)}
+        >
+          {i}
+        </button>
+      );
+    }
+    pages.push(
+      <button key="next" className="page-btn page-arrow" onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}>›</button>,
+      <button key="last" className="page-btn page-arrow" onClick={() => setCurrentPage(totalPages)}>»</button>
+    );
+    return pages;
+  };
 
   return (
     <div className="community-wrapper">
       <div className="community-container">
+
+        {/* 배너 */}
+        <div className="page-banner">
+          <div className="page-banner-text">
+            <h2 className="page-banner-title">커뮤니티</h2>
+            <p className="page-banner-sub">AI가 분석한 위험 조항을 공유하고, 실제 계약 사례와 사용자 후기를 확인해보세요.</p>
+          </div>
+        </div>
+
         {/* 헤더 */}
         <div className="community-header">
-          <h1 className="community-title">커뮤니티</h1>
+          <h1 className="community-title">전체 게시글</h1>
           <button className="write-btn" onClick={() => navigate('/community/write')}>
             글쓰기
           </button>
@@ -136,7 +144,7 @@ const pagedPosts = posts.slice(
           <div className="search-box">
             <input
               type="text"
-              placeholder="커뮤니티 검색하기"
+              placeholder="게시글을 검색해보세요"
               value={searchQuery}
               onChange={e => {
                 setSearchQuery(e.target.value);
@@ -171,7 +179,7 @@ const pagedPosts = posts.slice(
             pagedPosts.map(post => (
               <PostCard key={post.id} post={post} />
             ))
-  )}
+          )}
         </div>
 
         {/* 페이지네이션 */}

--- a/frontend/src/pages/FormPage.css
+++ b/frontend/src/pages/FormPage.css
@@ -1,12 +1,37 @@
 .form-page {
   min-height: 100vh;
   background: #fff; 
-  padding: 30px 20px; 
+  padding: 40px 20px; 
 } 
 
 .form-container {
   width: 1024px;
   margin: 0 auto;
+}
+
+.form-banner {
+  padding: 0px 0px 24px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #F1F5F9
+}
+ 
+.form-banner-icon {
+  display: none;
+}
+ 
+.form-banner-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: #1e293b;
+  margin: 0 0 6px;
+  letter-spacing: -0.3px;
+}
+ 
+.form-banner-sub {
+  font-size: 13px;
+  color: #64748b;
+  margin: 0;
+  line-height: 1.6;
 }
 
 .form-page-title {
@@ -129,3 +154,32 @@
   background: #93c5fd;
   cursor: not-allowed;
 }
+
+@media (min-width: 1600px) {
+  .form-page {
+    padding: 48px 40px;
+  }
+  .form-container {
+    width: 1300px;
+  }
+  .form-banner-title {
+    font-size: 26px;
+  }
+  .form-banner-sub {
+    font-size: 14px;
+  }
+  .form-card {
+    padding: 10px 20px;
+  }
+  .form-card-title {
+    font-size: 14px;
+  }
+  .form-card-source {
+    font-size: 13px;
+  }
+  .form-download-btn {
+    padding: 6px 12px;
+    font-size: 12px;
+  }
+}
+ 

--- a/frontend/src/pages/FormPage.tsx
+++ b/frontend/src/pages/FormPage.tsx
@@ -63,9 +63,15 @@ export default function FormPage() {
   return (
     <div className="form-page">
       <div className="form-container">
-        {/* 헤더 */}
-        <h1 className="form-page-title">법률 서식</h1>
-
+       {/* 배너 */}
+        <div className="form-banner">
+          <div className="form-banner-text">
+            <h2 className="form-banner-title">법률 서식</h2>
+            <p className="form-banner-sub">
+              부동산 계약에 필요한 표준 서식을 제공합니다. 임대차·매매·전세 계약서 등 다양한 서식을 다운로드하세요.
+            </p>
+          </div>
+        </div>
         {/* 검색 + 필터 */}
         <div className="controls-area">
           <div className="search-box">

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -65,6 +65,9 @@
   padding: 80px 24px 80px;
   background-image: url('../assets/img/BG2.svg');
   background-color: #e2cdcd;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
 }
 
 .hero-inner {
@@ -434,5 +437,36 @@
   .footer-inner {
     flex-direction: column;
     text-align: center;
+  }
+}
+
+@media (min-width: 1600px) {
+  .section-inner {
+    max-width: 1300px;
+  }
+  .hero-title {
+    font-size: 3.5rem;
+  }
+  .section-title {
+    font-size: 2.4rem;
+  }
+  .section-sub {
+    font-size: 1.05rem;
+  }
+  .how-section,
+  .features-section {
+    padding: 120px 0;
+  }
+  .feature-card {
+    padding: 60px 48px;
+  }
+  .feature-title {
+    font-size: 1.35rem;
+  }
+  .feature-desc {
+    font-size: 1.05rem;
+  }
+  .footer-inner {
+    max-width: 1300px;
   }
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -79,7 +79,9 @@ const features: { icon: ReactNode; title: string; desc: ReactNode }[] = [
  
       {/* ── Hero ── */}
       <section className="hero-section">
+        
         <div className="hero-inner reveal">
+          
           <h1 className="hero-title">
             복잡한 계약서를 쉽게 이해하도록<br />
             AI 법률 닥터<span className="hero-accent">AIDT</span>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -127,8 +127,8 @@ export default function LoginPage() {
           pb: 12,
         }}
       >
-        <Container maxWidth="xs">
-          <Box sx={{ borderRadius: borderRadius.lg, px: 4, py: 5 }}>
+        <Container maxWidth="xs" sx={{ maxWidth: { xl: '480px' } }}>
+          <Box sx={{ borderRadius: borderRadius.lg, px: { xs: 4, xl: 5 }, py: { xs: 5, xl: 6 } }}>
             {/* 로고 */}
             <Box
               component={RouterLink}
@@ -144,7 +144,7 @@ export default function LoginPage() {
               }}
             >
               <img src={LogoImg} width={24} height={24} />
-              <Typography sx={{ fontSize: '24px', fontWeight: 700, color: colors.gray[800] }}>
+              <Typography sx={{ fontSize: { xs: '24px', xl: '28px' }, fontWeight: 700, color: colors.gray[800] }}>
                 법닥
               </Typography>
             </Box>
@@ -152,7 +152,7 @@ export default function LoginPage() {
             <form onSubmit={handleSubmit}>
               {/* 이메일 */}
               <Box sx={{ mb: 2 }}>
-                <Typography sx={{ fontSize: '13px', fontWeight: 500, color: colors.gray[700], mb: 1 }}>
+                <Typography sx={{ fontSize: { xs: '13px', xl: '15px' }, fontWeight: 500, color: colors.gray[700], mb: 1 }}>
                   아이디
                 </Typography>
                 <TextField
@@ -165,8 +165,8 @@ export default function LoginPage() {
                   sx={{
                     '& .MuiOutlinedInput-root': {
                       background: '#ffffff',
-                      height: inputSizes.medium.height,
-                      fontSize: inputSizes.medium.fontSize,
+                      height: { xs: inputSizes.medium.height, xl: '48px' },
+                      fontSize: { xs: inputSizes.medium.fontSize, xl: '15px' },
                       fontFamily: "'KoPub', sans-serif",
                       '& fieldset': { borderColor: errors.email ? colors.error : colors.gray[300] },
                       '&:hover fieldset': { borderColor: errors.email ? colors.error : colors.gray[400] },
@@ -183,7 +183,7 @@ export default function LoginPage() {
 
               {/* 비밀번호 */}
               <Box sx={{ mb: 1 }}>
-                <Typography sx={{ fontSize: '13px', fontWeight: 500, color: colors.gray[700], mb: 1 }}>
+                <Typography sx={{ fontSize: { xs: '13px', xl: '15px' }, fontWeight: 500, color: colors.gray[700], mb: 1 }}>
                   비밀번호
                 </Typography>
                 <TextField
@@ -214,8 +214,8 @@ export default function LoginPage() {
                   sx={{
                     '& .MuiOutlinedInput-root': {
                       background: '#ffffff',
-                      height: inputSizes.medium.height,
-                      fontSize: inputSizes.medium.fontSize,
+                      height: { xs: inputSizes.medium.height, xl: '48px' },
+                      fontSize: { xs: inputSizes.medium.fontSize, xl: '15px' },
                       '& fieldset': { borderColor: errors.password ? colors.error : colors.gray[300] },
                       '&:hover fieldset': { borderColor: errors.password ? colors.error : colors.gray[400] },
                       '&.Mui-focused fieldset': { borderColor: errors.password ? colors.error : colors.primary.main, borderWidth: '1px' },
@@ -241,7 +241,7 @@ export default function LoginPage() {
                     />
                   }
                   label={
-                    <Typography sx={{ fontSize: '13px', color: colors.gray[600] }}>아이디 저장</Typography>
+                    <Typography sx={{ fontSize: { xs: '13px', xl: '14px' }, color: colors.gray[600] }}>아이디 저장</Typography>
                   }
                 />
               </Box>
@@ -252,8 +252,8 @@ export default function LoginPage() {
                 type="submit"
                 disabled={loading}
                 sx={{
-                  height: buttonSizes.medium.height,
-                  fontSize: buttonSizes.medium.fontSize,
+                  height: { xs: buttonSizes.medium.height, xl: '48px' },
+                  fontSize: { xs: buttonSizes.medium.fontSize, xl: '16px' },
                   fontWeight: 600,
                   background: colors.primary.main,
                   color: 'white',
@@ -274,16 +274,15 @@ export default function LoginPage() {
                 </Typography>
               </Divider>
 
-              {/* ✅ 소셜 로그인 버튼 — 수평 반씩 배치 */}
+              {/* 소셜 로그인 버튼 */}
               <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
-                {/* 구글 */}
                 <Button
                   fullWidth
                   onClick={handleGoogleLogin}
                   disabled={loading}
                   sx={{
-                    height: buttonSizes.medium.height,
-                    fontSize: '13px',
+                    height: { xs: buttonSizes.medium.height, xl: '48px' },
+                    fontSize: { xs: '13px', xl: '14px' },
                     fontWeight: 500,
                     background: '#ffffff',
                     color: colors.gray[700],
@@ -299,14 +298,13 @@ export default function LoginPage() {
                   Google
                 </Button>
 
-                {/* 카카오 */}
                 <Button
                   fullWidth
                   onClick={handleKakaoLogin}
                   disabled={loading}
                   sx={{
-                    height: buttonSizes.medium.height,
-                    fontSize: '13px',
+                    height: { xs: buttonSizes.medium.height, xl: '48px' },
+                    fontSize: { xs: '13px', xl: '14px' },
                     fontWeight: 500,
                     background: '#FEE500',
                     color: '#3C1E1E',
@@ -325,15 +323,15 @@ export default function LoginPage() {
 
               {/* 하단 링크 */}
               <Box sx={{ display: 'flex', justifyContent: 'center', gap: 2 }}>
-                <Link href="#" underline="none" sx={{ fontSize: '13px', color: colors.gray[600], '&:hover': { color: colors.gray[800] } }}>
+                <Link href="#" underline="none" sx={{ fontSize: { xs: '13px', xl: '14px' }, color: colors.gray[600], '&:hover': { color: colors.gray[800] } }}>
                   아이디 찾기
                 </Link>
                 <Box sx={{ color: colors.gray[300] }}>|</Box>
-                <Link href="#" underline="none" sx={{ fontSize: '13px', color: colors.gray[600], '&:hover': { color: colors.gray[800] } }}>
+                <Link href="#" underline="none" sx={{ fontSize: { xs: '13px', xl: '14px' }, color: colors.gray[600], '&:hover': { color: colors.gray[800] } }}>
                   비밀번호 재설정
                 </Link>
                 <Box sx={{ color: colors.gray[300] }}>|</Box>
-                <Link component={RouterLink} to="/signup" underline="none" sx={{ fontSize: '13px', color: colors.gray[600], '&:hover': { color: colors.gray[800] } }}>
+                <Link component={RouterLink} to="/signup" underline="none" sx={{ fontSize: { xs: '13px', xl: '14px' }, color: colors.gray[600], '&:hover': { color: colors.gray[800] } }}>
                   회원가입
                 </Link>
               </Box>

--- a/frontend/src/pages/PostdetailPage.tsx
+++ b/frontend/src/pages/PostdetailPage.tsx
@@ -147,12 +147,6 @@ const handleCommentDislike = (commentId: string) => {
   return (
     <div className="post-detail-wrapper">
       <div className="post-detail-container">
-        <button className="back-btn" onClick={() => navigate('/community')}>
-          <span className='back-btn-icon'>
-            <IoChevronBackCircle size={'20px'} />
-          </span>
-          목록으로
-        </button>
 
         {/* 본문 */}
         <div className="post-detail-card">

--- a/frontend/src/pages/SchedulePage.css
+++ b/frontend/src/pages/SchedulePage.css
@@ -760,3 +760,59 @@
   margin: 0;
   line-height: 1.6;
 }
+
+@media (min-width: 1600px) {
+  .schedule-layout {
+    padding: 16px;
+    gap: 0px;
+  }
+
+  .schedule-left {
+    width: 360px;
+    height: calc(100vh - 90px);
+    padding: 20px;
+  }
+
+  .react-calendar__navigation__label {
+    font-size: 18px !important;
+  }
+
+  .react-calendar__tile {
+    font-size: 15px !important;
+  }
+
+  .schedule-right {
+    padding: 24px 24px;
+  }
+
+  .schedule-page-title {
+    font-size: 26px;
+    margin-bottom: 28px;
+  }
+
+  .schedule-card {
+    padding: 10px 20px;
+    gap: 30px;
+  }
+
+  .schedule-card-title-inline {
+    font-size: 14px;
+  }
+
+  .schedule-dday-text {
+    font-size: 14px;
+    min-width: 56px;
+  }
+
+  .calendar-month-title {
+    font-size: 14px;
+  }
+
+  .calendar-month-item-title {
+    font-size: 14px;
+  }
+
+  .controls-area {
+    gap: 12px;
+  }
+}

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -22,9 +22,6 @@ import { IoClose } from 'react-icons/io5';
 import { useAuth } from '../context/AuthContext';
 import { colors, buttonSizes, inputSizes, borderRadius } from '../styles/theme';
 
-// ============================
-// 약관 내용
-// ============================
 const TERMS_CONTENT = `제1조 (목적)
 본 약관은 법닥(이하 "서비스")이 제공하는 AI 기반 부동산 계약서 분석 서비스의 이용에 관한 조건 및 절차, 기타 필요한 사항을 규정함을 목적으로 합니다.
 
@@ -51,9 +48,6 @@ const PRIVACY_CONTENT = `1. 수집하는 개인정보 항목
 4. 개인정보 제3자 제공
 수집된 개인정보는 제3자에게 제공하지 않습니다.`;
 
-// ============================
-// 약관 모달
-// ============================
 function AgreementModal({
   title,
   content,
@@ -82,7 +76,7 @@ function AgreementModal({
           background: '#fff',
           borderRadius: '16px',
           width: '100%',
-          maxWidth: '480px',
+          maxWidth: { xs: '480px', xl: '560px' },
           maxHeight: '80vh',
           display: 'flex',
           flexDirection: 'column',
@@ -90,7 +84,6 @@ function AgreementModal({
         }}
         onClick={e => e.stopPropagation()}
       >
-        {/* 헤더 */}
         <Box sx={{
           display: 'flex',
           justifyContent: 'space-between',
@@ -98,17 +91,16 @@ function AgreementModal({
           p: '16px 20px',
           borderBottom: '1px solid #f1f5f9',
         }}>
-          <Typography sx={{ fontSize: '16px', fontWeight: 700, color: '#1e293b' }}>
+          <Typography sx={{ fontSize: { xs: '16px', xl: '18px' }, fontWeight: 700, color: '#1e293b' }}>
             {title}
           </Typography>
           <IconButton onClick={onClose} size="small">
             <IoClose size={20} color="#94a3b8" />
           </IconButton>
         </Box>
-        {/* 내용 */}
         <Box sx={{ p: '20px', overflowY: 'auto' }}>
           <Typography sx={{
-            fontSize: '13px',
+            fontSize: { xs: '13px', xl: '14px' },
             lineHeight: 1.8,
             color: '#475569',
             whiteSpace: 'pre-line',
@@ -116,13 +108,13 @@ function AgreementModal({
             {content}
           </Typography>
         </Box>
-        {/* 확인 버튼 */}
         <Box sx={{ p: '12px 20px', borderTop: '1px solid #f1f5f9' }}>
           <Button
             fullWidth
             onClick={onClose}
             sx={{
-              height: '40px',
+              height: { xs: '40px', xl: '46px' },
+              fontSize: { xs: '14px', xl: '15px' },
               background: colors.primary.main,
               color: '#fff',
               borderRadius: '8px',
@@ -139,9 +131,6 @@ function AgreementModal({
   );
 }
 
-// ============================
-// 회원가입 페이지
-// ============================
 export default function SignupPage() {
   const [name, setName] = useState('');
   const [birthYear, setBirthYear] = useState('');
@@ -164,8 +153,6 @@ export default function SignupPage() {
     agreements: '',
   });
   const [loading, setLoading] = useState(false);
-
-  // ✅ 약관 모달 상태
   const [modalType, setModalType] = useState<'terms' | 'privacy' | null>(null);
 
   const { signup } = useAuth();
@@ -236,30 +223,28 @@ export default function SignupPage() {
   const textFieldSx = (hasError: boolean) => ({
     '& .MuiOutlinedInput-root': {
       background: '#ffffff',
-      height: inputSizes.medium.height,
-      fontSize: inputSizes.medium.fontSize,
+      height: { xs: inputSizes.medium.height, xl: '48px' },
+      fontSize: { xs: inputSizes.medium.fontSize, xl: '15px' },
       '& fieldset': { borderColor: hasError ? colors.error : colors.gray[300] },
       '&:hover fieldset': { borderColor: hasError ? colors.error : colors.gray[400] },
       '&.Mui-focused fieldset': { borderColor: hasError ? colors.error : colors.primary.main, borderWidth: '1px' },
     },
   });
 
+  const labelSx = {
+    fontSize: { xs: '13px', xl: '15px' },
+    fontWeight: 500,
+    color: colors.gray[700],
+    mb: 0.5,
+  };
+
   return (
     <>
-      {/* ✅ 약관 모달 */}
       {modalType === 'terms' && (
-        <AgreementModal
-          title="이용약관"
-          content={TERMS_CONTENT}
-          onClose={() => setModalType(null)}
-        />
+        <AgreementModal title="이용약관" content={TERMS_CONTENT} onClose={() => setModalType(null)} />
       )}
       {modalType === 'privacy' && (
-        <AgreementModal
-          title="개인정보 수집 및 이용"
-          content={PRIVACY_CONTENT}
-          onClose={() => setModalType(null)}
-        />
+        <AgreementModal title="개인정보 수집 및 이용" content={PRIVACY_CONTENT} onClose={() => setModalType(null)} />
       )}
 
       <Box sx={{
@@ -270,16 +255,16 @@ export default function SignupPage() {
         background: colors.gray[50],
         py: 4,
       }}>
-        <Container maxWidth="xs">
-          <Box sx={{ borderRadius: borderRadius.lg, px: 4, py: 5 }}>
-            <Typography sx={{ fontSize: '24px', fontWeight: 700, color: colors.gray[800], mb: 5, textAlign: 'center' }}>
+        <Container maxWidth="xs" sx={{ maxWidth: { xl: '480px' } }}>
+          <Box sx={{ borderRadius: borderRadius.lg, px: { xs: 4, xl: 5 }, py: { xs: 5, xl: 6 } }}>
+            <Typography sx={{ fontSize: { xs: '24px', xl: '28px' }, fontWeight: 700, color: colors.gray[800], mb: 5, textAlign: 'center' }}>
               회원가입
             </Typography>
 
             <form onSubmit={handleSubmit}>
               {/* 이름 */}
               <Box sx={{ mb: 2 }}>
-                <Typography sx={{ fontSize: '13px', fontWeight: 500, color: colors.gray[700], mb: 0.5 }}>이름</Typography>
+                <Typography sx={labelSx}>이름</Typography>
                 <TextField
                   fullWidth
                   placeholder="이름을 입력하세요"
@@ -294,7 +279,7 @@ export default function SignupPage() {
 
               {/* 출생년도 */}
               <Box sx={{ mb: 2 }}>
-                <Typography sx={{ fontSize: '13px', fontWeight: 500, color: colors.gray[700], mb: 0.5 }}>출생년도</Typography>
+                <Typography sx={labelSx}>출생년도</Typography>
                 <FormControl fullWidth>
                   <Select
                     value={birthYear}
@@ -304,8 +289,8 @@ export default function SignupPage() {
                     IconComponent={KeyboardArrowDown}
                     sx={{
                       background: '#ffffff',
-                      height: inputSizes.medium.height,
-                      fontSize: inputSizes.medium.fontSize,
+                      height: { xs: inputSizes.medium.height, xl: '48px' },
+                      fontSize: { xs: inputSizes.medium.fontSize, xl: '15px' },
                       '& .MuiOutlinedInput-notchedOutline': { borderColor: colors.gray[300] },
                       '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: colors.gray[400] },
                       '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: colors.primary.main, borderWidth: '1px' },
@@ -323,7 +308,7 @@ export default function SignupPage() {
 
               {/* 이메일 */}
               <Box sx={{ mb: 2 }}>
-                <Typography sx={{ fontSize: '13px', fontWeight: 500, color: colors.gray[700], mb: 0.5 }}>이메일</Typography>
+                <Typography sx={labelSx}>이메일</Typography>
                 <TextField
                   fullWidth
                   placeholder="example@email.com"
@@ -338,7 +323,7 @@ export default function SignupPage() {
 
               {/* 비밀번호 */}
               <Box sx={{ mb: 2 }}>
-                <Typography sx={{ fontSize: '13px', fontWeight: 500, color: colors.gray[700], mb: 0.5 }}>비밀번호</Typography>
+                <Typography sx={labelSx}>비밀번호</Typography>
                 <TextField
                   fullWidth
                   type={showPassword ? 'text' : 'password'}
@@ -365,7 +350,7 @@ export default function SignupPage() {
 
               {/* 비밀번호 확인 */}
               <Box sx={{ mb: 3 }}>
-                <Typography sx={{ fontSize: '13px', fontWeight: 500, color: colors.gray[700], mb: 0.5 }}>비밀번호 확인</Typography>
+                <Typography sx={labelSx}>비밀번호 확인</Typography>
                 <TextField
                   fullWidth
                   type={showConfirmPassword ? 'text' : 'password'}
@@ -398,7 +383,6 @@ export default function SignupPage() {
                 borderRadius: borderRadius.md,
                 background: '#ffffff',
               }}>
-                {/* 전체 동의 */}
                 <FormControlLabel
                   control={
                     <Checkbox
@@ -407,12 +391,11 @@ export default function SignupPage() {
                       sx={{ color: colors.gray[400], '&.Mui-checked': { color: colors.primary.main } }}
                     />
                   }
-                  label={<Typography sx={{ fontSize: '14px', fontWeight: 600, color: colors.gray[800] }}>전체동의</Typography>}
+                  label={<Typography sx={{ fontSize: { xs: '14px', xl: '15px' }, fontWeight: 600, color: colors.gray[800] }}>전체동의</Typography>}
                   sx={{ mb: 1 }}
                 />
 
                 <Box sx={{ pl: 3, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                  {/* 만 14세 */}
                   <FormControlLabel
                     control={
                       <Checkbox
@@ -423,13 +406,12 @@ export default function SignupPage() {
                       />
                     }
                     label={
-                      <Typography sx={{ fontSize: '13px', color: colors.gray[600] }}>
+                      <Typography sx={{ fontSize: { xs: '13px', xl: '14px' }, color: colors.gray[600] }}>
                         만 14세 이상입니다 <span style={{ color: colors.error }}>(필수)</span>
                       </Typography>
                     }
                   />
 
-                  {/* 이용약관 */}
                   <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                     <FormControlLabel
                       control={
@@ -441,12 +423,11 @@ export default function SignupPage() {
                         />
                       }
                       label={
-                        <Typography sx={{ fontSize: '13px', color: colors.gray[600] }}>
+                        <Typography sx={{ fontSize: { xs: '13px', xl: '14px' }, color: colors.gray[600] }}>
                           이용약관 <span style={{ color: colors.error }}>(필수)</span>
                         </Typography>
                       }
                     />
-                    {/* ✅ 보기 버튼 */}
                     <Typography
                       onClick={() => setModalType('terms')}
                       sx={{ fontSize: '12px', color: colors.primary.main, cursor: 'pointer', textDecoration: 'underline', flexShrink: 0, mr: 1 }}
@@ -455,7 +436,6 @@ export default function SignupPage() {
                     </Typography>
                   </Box>
 
-                  {/* 개인정보 수집 및 이용 */}
                   <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                     <FormControlLabel
                       control={
@@ -467,12 +447,11 @@ export default function SignupPage() {
                         />
                       }
                       label={
-                        <Typography sx={{ fontSize: '13px', color: colors.gray[600] }}>
+                        <Typography sx={{ fontSize: { xs: '13px', xl: '14px' }, color: colors.gray[600] }}>
                           개인정보 수집 및 이용 <span style={{ color: colors.error }}>(필수)</span>
                         </Typography>
                       }
                     />
-                    {/* ✅ 보기 버튼 */}
                     <Typography
                       onClick={() => setModalType('privacy')}
                       sx={{ fontSize: '12px', color: colors.primary.main, cursor: 'pointer', textDecoration: 'underline', flexShrink: 0, mr: 1 }}
@@ -481,7 +460,6 @@ export default function SignupPage() {
                     </Typography>
                   </Box>
 
-                  {/* 마케팅 동의 */}
                   <FormControlLabel
                     control={
                       <Checkbox
@@ -492,7 +470,7 @@ export default function SignupPage() {
                       />
                     }
                     label={
-                      <Typography sx={{ fontSize: '13px', color: colors.gray[600] }}>
+                      <Typography sx={{ fontSize: { xs: '13px', xl: '14px' }, color: colors.gray[600] }}>
                         광고성 정보 수신 및 마케팅 활용 동의 (선택)
                       </Typography>
                     }
@@ -500,7 +478,6 @@ export default function SignupPage() {
                 </Box>
               </Box>
 
-              {/* 약관 에러 */}
               {errors.agreements && (
                 <FormHelperText error sx={{ ml: 0, mt: -2, mb: 2, fontSize: '12px' }}>{errors.agreements}</FormHelperText>
               )}
@@ -511,8 +488,8 @@ export default function SignupPage() {
                 type="submit"
                 disabled={loading}
                 sx={{
-                  height: buttonSizes.medium.height,
-                  fontSize: buttonSizes.medium.fontSize,
+                  height: { xs: buttonSizes.medium.height, xl: '48px' },
+                  fontSize: { xs: buttonSizes.medium.fontSize, xl: '16px' },
                   fontWeight: 600,
                   background: colors.primary.main,
                   color: 'white',
@@ -526,9 +503,8 @@ export default function SignupPage() {
                 {loading ? '가입 중...' : '회원가입'}
               </Button>
 
-              {/* 로그인 링크 */}
               <Box sx={{ textAlign: 'center' }}>
-                <Typography sx={{ fontSize: '13px', color: colors.gray[600] }}>
+                <Typography sx={{ fontSize: { xs: '13px', xl: '14px' }, color: colors.gray[600] }}>
                   이미 아이디가 있으신가요?{' '}
                   <Link component={RouterLink} to="/login" underline="none" sx={{ fontWeight: 600, color: colors.primary.main }}>
                     로그인


### PR DESCRIPTION
## 변경 사항

### 위험탐지 (DangerView)
- 블록 분리 방식 줄 단위 → p태그 기준 문단 단위로 변경
- 매칭 로직 개선 (5단계 점수 기반, normalizeText 정규화 적용)
- 블록당 최대 2개 매칭 제한으로 오매칭 방지

### 개인정보 마스킹 (DocumentEditor, AiPage)
- 마스킹 텍스트 노란색 하이라이팅
- MaskedText TipTap Extension 추가
- maskPersonalInfo span 태그 적용

### 큰 데스크톱 반응형 (1600px+)
- 마이페이지 레이아웃, 사이드바, 각 탭 폰트/패딩 확대
- AI 분석 페이지 컨텐츠 박스 너비 확장
- 홈페이지, 커뮤니티, 폼 페이지 반응형 추가

### 커뮤니티 검색 (post_controller)
- 제목만 검색 → 제목+내용 동시 검색으로 확장

## 위험탐지 매칭 현황 및 AI 개선 요청

### 현재 문제점
- AI가 반환하는 `clauseText`가 계약서 원문이 아닌 재구성/요약된 텍스트로 반환됨
- 표(table) 안의 텍스트는 여러 셀에 분산되어 있어 clauseText와 매칭 불가
- 결과적으로 위험 조항 본문 하이라이팅 매칭 실패 발생

### AI팀 개선 요청 사항
- `clauseText`를 계약서 원문에서 해당 위험 조항 문장을 그대로 복사하여 반환
- AI가 재구성하거나 요약한 텍스트가 아닌 계약서에 실제 존재하는 문장 그대로
- 조항 번호(제4조, ①, 특약사항 제3항 등)가 있으면 반드시 포함
